### PR TITLE
Rename `--ruledir` to `--rulesdir`

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ eslint-interactive [file.js] [dir]
 Options:
   --help     Show help                                                 [boolean]
   --version  Show version number                                       [boolean]
-  --ruledir  Use additional rules from this directory                    [array]
+  --rulesdir  Use additional rules from this directory                    [array]
   --ext      Specify JavaScript file extensions                          [array]
   --format   Specify the format to be used for the `Display problem messages`
              action                              [string] [default: "codeframe"]
@@ -61,7 +61,7 @@ $ eslint-interactive ./src
 $ eslint-interactive ./src ./test
 $ eslint-interactive './src/**/*.{ts,tsx,vue}'
 $ eslint-interactive ./src --ext .ts,.tsx,.vue
-$ eslint-interactive ./src --ruledir ./rules
+$ eslint-interactive ./src --rulesdir ./rules
 ```
 
 ## Differences from related works

--- a/README.md
+++ b/README.md
@@ -48,12 +48,12 @@ $ eslint-interactive --help
 eslint-interactive [file.js] [dir]
 
 Options:
-  --help     Show help                                                 [boolean]
-  --version  Show version number                                       [boolean]
-  --rulesdir  Use additional rules from this directory                    [array]
-  --ext      Specify JavaScript file extensions                          [array]
-  --format   Specify the format to be used for the `Display problem messages`
-             action                              [string] [default: "codeframe"]
+  --help      Show help                                                [boolean]
+  --version   Show version number                                      [boolean]
+  --rulesdir  Use additional rules from this directory                   [array]
+  --ext       Specify JavaScript file extensions                         [array]
+  --format    Specify the format to be used for the `Display problem messages`
+              action                             [string] [default: "codeframe"]
 
 
 $ # Examples

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "private": false,
   "scripts": {
     "build": "tsc -p tsconfig.src.json",
-    "dev": "tsc-watch -p tsconfig.src.json --onSuccess 'bin/eslint-interactive fixtures --ruledir fixtures/rules --ext .js,jsx,.mjs'",
+    "dev": "tsc-watch -p tsconfig.src.json --onSuccess 'bin/eslint-interactive fixtures --rulesdir fixtures/rules --ext .js,jsx,.mjs'",
     "lint": "run-s -c lint:*",
     "lint:tsc": "run-s -c lint:tsc:*",
     "lint:tsc:src": "tsc -p tsconfig.src.json --noEmit",

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,11 +20,11 @@ export type Options = {
 export async function run(options: Options) {
   const argv = yargs(options.argv.slice(2))
     .usage('$0 [file.js] [dir]')
-    .option('ruledir', {
+    .option('rulesdir', {
       type: 'array',
       describe: 'Use additional rules from this directory',
     })
-    .nargs('ruledir', 1)
+    .nargs('rulesdir', 1)
     .option('ext', {
       type: 'array',
       describe: 'Specify JavaScript file extensions',
@@ -38,7 +38,7 @@ export async function run(options: Options) {
   // NOTE: convert `string` type because yargs convert `'10'` (`string` type) into `10` (`number` type)
   // and `lintFiles` only accepts `string[]`.
   const patterns = argv._.map((pattern) => pattern.toString());
-  const rulePaths = argv.ruledir?.map((rulePath) => rulePath.toString());
+  const rulePaths = argv.rulesdir?.map((rulePath) => rulePath.toString());
   const extensions = argv.ext
     ?.map((extension) => extension.toString())
     // map '.js,.ts' into ['.js', '.ts']


### PR DESCRIPTION
The option to load user-defined rules is called `--ruledir` in eslint-interactive. On the other hand, in eslint it is called `--rulesdir`.

The difference in naming may confuse users. So I want to rename `--ruledir` to `--rulesdir`.