### PR TITLE
eslint-interactive installed globally will no longer be officially supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,18 +33,22 @@ Also, You can perform the following actions for each rule:
 ## Installation
 
 ```console
-$ npm i -g eslint @mizdra/eslint-interactive
-$ eslint-interactive --help
+$ # For npm
+$ npm i -D @mizdra/eslint-interactive
+$ npx eslint-interactive --help
 
-$ # or npx
-$ npx -p eslint -p @mizdra/eslint-interactive eslint-interactive --help
+$ # For yarn
+$ yarn add @mizdra/eslint-interactive
+$ yarn eslint-interactive --help
 ```
+
+NOTE: The globally installed eslint-interactive is not officially supported because some features do not work. It is recommended to install eslint-interactive locally. See [#77](https://github.com/mizdra/eslint-interactive/issues/77).
 
 ## Usage
 
 ```console
 $ # Show help
-$ eslint-interactive --help
+$ npx eslint-interactive --help
 eslint-interactive [file.js] [dir]
 
 Options:
@@ -57,11 +61,11 @@ Options:
 
 
 $ # Examples
-$ eslint-interactive ./src
-$ eslint-interactive ./src ./test
-$ eslint-interactive './src/**/*.{ts,tsx,vue}'
-$ eslint-interactive ./src --ext .ts,.tsx,.vue
-$ eslint-interactive ./src --rulesdir ./rules
+$ npx eslint-interactive ./src
+$ npx eslint-interactive ./src ./test
+$ npx eslint-interactive './src/**/*.{ts,tsx,vue}'
+$ npx eslint-interactive ./src --ext .ts,.tsx,.vue
+$ npx eslint-interactive ./src --rulesdir ./rules
 ```
 
 ## Differences from related works

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "cli-table": "^0.3.9",
     "enquirer": "^2.3.6",
     "eslint-formatter-codeframe": "^7.32.1",
+    "is-installed-globally": "^0.4.0",
     "node-pager": "^0.3.6",
     "ora": "^5.1.0",
     "source-map-support": "^0.5.20",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+import chalk from 'chalk';
+import isInstalledGlobally from 'is-installed-globally';
 import { parseArgv } from './cli/parse-argv';
 import { Core } from './core';
 import { lint } from './scenes/lint';
@@ -14,6 +16,15 @@ export type Options = {
  * Run eslint-interactive.
  */
 export async function run(options: Options) {
+  if (isInstalledGlobally) {
+    console.log(
+      chalk.bold.yellowBright(
+        'WARNING: eslint-interactive is installed globally. ' +
+          'The globally installed eslint-interactive is not officially supported because some features do not work. ' +
+          'It is recommended to install eslint-interactive locally.\n',
+      ),
+    );
+  }
   const config = parseArgv(options.argv);
   const core = new Core(config);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1820,6 +1820,13 @@ glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+global-dirs@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/global-dirs/-/global-dirs-3.0.0.tgz#70a76fe84ea315ab37b1f5576cbde7d48ef72686"
+  integrity sha512-v8ho2DS5RiCjftj1nD9NmnfaOzTdud7RRnVd9kFNOjqZbISlx5DQ+OrTkywgd0dIt7oFCvKetZSHoHcP3sDdiA==
+  dependencies:
+    ini "2.0.0"
+
 globals@^11.1.0:
   version "11.12.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
@@ -1973,6 +1980,11 @@ inherits@2:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
+ini@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ini/-/ini-2.0.0.tgz#e5fd556ecdd5726be978fa1001862eacb0a94bc5"
+  integrity sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==
+
 internal-slot@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/internal-slot/-/internal-slot-1.0.3.tgz#7347e307deeea2faac2ac6205d4bc7d34967f59c"
@@ -2048,6 +2060,14 @@ is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3:
   dependencies:
     is-extglob "^2.1.1"
 
+is-installed-globally@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/is-installed-globally/-/is-installed-globally-0.4.0.tgz#9a0fd407949c30f86eb6959ef1b7994ed0b7b520"
+  integrity sha512-iwGqO3J21aaSkC7jWnHP/difazwS7SFeIqxv6wEtLU8Y5KlzFTjyqcSIT0d8s4+dDhKytsk9PJZ2BkS5eZwQRQ==
+  dependencies:
+    global-dirs "^3.0.0"
+    is-path-inside "^3.0.2"
+
 is-interactive@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-interactive/-/is-interactive-1.0.0.tgz#cea6e6ae5c870a7b0a0004070b7b587e0252912e"
@@ -2069,6 +2089,11 @@ is-number@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
+
+is-path-inside@^3.0.2:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-3.0.3.tgz#d231362e53a07ff2b0e0ea7fed049161ffd16283"
+  integrity sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==
 
 is-potential-custom-element-name@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
close: #77 

- The global installation of eslint-interactive will no longer be officially supported
- Warn if a global installation of eslint-interactive is used
- Local installation is recommended from now on.

## Screenshot

<img width="1139" alt=" 2021-12-12 17 34 23" src="https://user-images.githubusercontent.com/9639995/145705830-b18aa6f3-a15b-4723-87c9-1bea368471e3.png">
