### PR TITLE
Fix failure of eslint-interactive to start on Ubuntu

### DIFF
--- a/bin/eslint-interactive
+++ b/bin/eslint-interactive
@@ -1,4 +1,4 @@
-#!/usr/bin/env node -r source-map-support/register
+#!/usr/bin/env -S node -r source-map-support/register
 
 const { run } = require('../dist');
 


### PR DESCRIPTION
fix: #93 