### PR TITLE
Fix not working with Node.js v14.x

### DIFF
--- a/src/core-worker.ts
+++ b/src/core-worker.ts
@@ -1,4 +1,4 @@
-import { parentPort } from 'worker_threads';
+import { parentPort, MessageChannel } from 'worker_threads';
 import { expose } from 'comlink';
 import nodeEndpoint from 'comlink/dist/esm/node-adapter.mjs';
 import { ESLint } from 'eslint';
@@ -57,5 +57,10 @@ export class SerializableCore {
     return this.core.makeFixableAndFix(results, ruleIds, fixableMaker);
   }
 }
+
+// workaround for https://github.com/GoogleChromeLabs/comlink/issues/466
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).MessageChannel = MessageChannel;
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 expose(SerializableCore, (nodeEndpoint as any)(parentPort));


### PR DESCRIPTION
## Before

```console
$ eslint-interactive .
┌ WARNING ──────────────────────────────────────────────────────────────────────────────────────────────┐
│ eslint-interactive is installed globally. The globally installed eslint-interactive is not officially │
│ supported because some features do not work. It is recommended to install eslint-interactive locally. │
└───────────────────────────────────────────────────────────────────────────────────────────────────────┘
(node:81681) UnhandledPromiseRejectionWarning: ReferenceError: MessageChannel is not defined
    at Object.serialize (/Users/mizdra/.anyenv/envs/nodenv/versions/14.18.2/lib/node_modules/@mizdra/eslint-interactive/node_modules/comlink/src/comlink.ts:219:30)
    at toWireValue (/Users/mizdra/.anyenv/envs/nodenv/versions/14.18.2/lib/node_modules/@mizdra/eslint-interactive/node_modules/comlink/src/comlink.ts:498:56)
    at /Users/mizdra/.anyenv/envs/nodenv/versions/14.18.2/lib/node_modules/@mizdra/eslint-interactive/node_modules/comlink/src/comlink.ts:344:44
(Use `node --trace-warnings ...` to show where the warning was created)
(node:81681) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
(node:81681) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

## After

```console
$ eslint-interactive .
┌ WARNING ──────────────────────────────────────────────────────────────────────────────────────────────┐
│ eslint-interactive is installed globally. The globally installed eslint-interactive is not officially │
│ supported because some features do not work. It is recommended to install eslint-interactive locally. │
└───────────────────────────────────────────────────────────────────────────────────────────────────────┘
🌒  Linting...Warning: React version was set to "detect" in eslint-plugin-react settings, but the "react" package is not installed. Assuming latest React version for linting.
✔ Linting was successful.

💚 No error found.
```
