### PR TITLE
feat: support --resolve-plugins-relative-to

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,17 +66,19 @@ $ npx eslint-interactive --help
 eslint-interactive [file.js] [dir]
 
 Options:
-      --help            Show help                                                                                                  [boolean]
-      --version         Show version number                                                                                        [boolean]
-      --eslintrc        Enable use of configuration from .eslintrc.*                                               [boolean] [default: true]
-  -c, --config          Use this configuration, overriding .eslintrc.* config options if present                                    [string]
-      --ext             Specify JavaScript file extensions                                                                           [array]
-      --rulesdir        Use additional rules from this directory                                                                     [array]
-      --ignore-path     Specify path of ignore file                                                                                 [string]
-      --format          Specify the format to be used for the `Display problem messages` action              [string] [default: "codeframe"]
-      --quiet           Report errors only                                                                        [boolean] [default: false]
-      --cache           Only check changed files                                                                   [boolean] [default: true]
-      --cache-location  Path to the cache file or directory [string] [default: "node_modules/.cache/eslint-interactive/10.5.0/.eslintcache"]
+      --help                         Show help                                                                                     [boolean]
+      --version                      Show version number                                                                           [boolean]
+      --eslintrc                     Enable use of configuration from .eslintrc.*                                  [boolean] [default: true]
+  -c, --config                       Use this configuration, overriding .eslintrc.* config options if present                       [string]
+      --resolve-plugins-relative-to  A folder where plugins should be resolved from, CWD by default                                 [string]
+      --ext                          Specify JavaScript file extensions                                                              [array]
+      --rulesdir                     Use additional rules from this directory                                                        [array]
+      --ignore-path                  Specify path of ignore file                                                                    [string]
+      --format                       Specify the format to be used for the `Display problem messages` action [string] [default: "codeframe"]
+      --quiet                        Report errors only                                                           [boolean] [default: false]
+      --cache                        Only check changed files                                                      [boolean] [default: true]
+      --cache-location               Path to the cache file or directory
+                                                            [string] [default: "node_modules/.cache/eslint-interactive/10.6.0/.eslintcache"]
 
 Examples:
   eslint-interactive ./src                                           Lint ./src/ directory

--- a/src/cli/parse-argv.ts
+++ b/src/cli/parse-argv.ts
@@ -26,6 +26,10 @@ export function parseArgv(argv: string[]): Config {
       describe: 'Specify JavaScript file extensions',
     })
     .nargs('ext', 1)
+    .option('resolve-plugins-relative-to', {
+      type: 'string',
+      describe: 'A folder where plugins should be resolved from, CWD by default',
+    })
     .option('rulesdir', {
       type: 'array',
       describe: 'Use additional rules from this directory',
@@ -73,6 +77,7 @@ export function parseArgv(argv: string[]): Config {
     // map '.js,.ts' into ['.js', '.ts']
     .flatMap((extension) => extension.split(','));
   const formatterName = parsedArgv.format;
+  const resolvePluginsRelativeTo = parsedArgv['resolve-plugins-relative-to'];
   return {
     patterns,
     useEslintrc: parsedArgv.eslintrc,
@@ -84,5 +89,6 @@ export function parseArgv(argv: string[]): Config {
     quiet: parsedArgv.quiet,
     cache: parsedArgv.cache,
     cacheLocation: parsedArgv['cache-location'],
+    resolvePluginsRelativeTo,
   };
 }

--- a/src/core.test.ts
+++ b/src/core.test.ts
@@ -89,6 +89,7 @@ describe('Core', () => {
       rulePaths: ['rule-path-a', 'rule-path-b'],
       extensions: ['.js', '.jsx'],
       cwd: '/tmp/cwd',
+      resolvePluginsRelativeTo: undefined,
     });
     const core2 = new Core({
       patterns: ['pattern-a', 'pattern-b'],
@@ -100,6 +101,7 @@ describe('Core', () => {
       rulePaths: undefined,
       extensions: undefined,
       cwd: undefined,
+      resolvePluginsRelativeTo: undefined,
     });
   });
   describe('lint', () => {

--- a/src/core.ts
+++ b/src/core.ts
@@ -61,6 +61,7 @@ export type Config = Pick<
   | 'cacheLocation'
   | 'overrideConfig'
   | 'cwd'
+  | 'resolvePluginsRelativeTo'
 > & {
   patterns: string[];
   formatterName?: string;
@@ -77,6 +78,7 @@ export const DEFAULT_BASE_CONFIG: Partial<Config> = {
   formatterName: 'codeframe',
   quiet: false,
   rulePaths: undefined,
+  resolvePluginsRelativeTo: undefined,
 };
 
 /**


### PR DESCRIPTION
# Summary

This Pull Request adds support for the `--resolve-plugins-relative-to` option in the `eslint-interactive`

## Background

In my monorepo project, I want to use the `eslint-interactive` tool, but it requires support for the `--resolve-plugins-relative-to` option which is available in ESLint. 

## Tests

Although no new tests have been added, I have manually tested this change by building and executing `node /path/to/eslint-interactive/bin/eslint-interactive.js --resolve-plugins-relative-to=...` command, and confirmed that it works correctly.
