### PR TITLE
Change `Options` interface of `Core` class

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,6 +6,7 @@
       "type": "node",
       "request": "launch",
       "cwd": "${workspaceFolder}",
+      "console": "integratedTerminal",
       "runtimeExecutable": "pnpm",
       "runtimeArgs": ["run", "dev"]
     }

--- a/benchmark/run-cachegrind-benchmarking.js
+++ b/benchmark/run-cachegrind-benchmarking.js
@@ -5,5 +5,5 @@ import { Core } from '../dist/core.js';
 
 const __dirname = join(dirname(fileURLToPath(import.meta.url)));
 
-const core = new Core({ patterns: ['fixtures'], cwd: __dirname });
+const core = new Core({ patterns: ['fixtures'], eslintOptions: { cwd: __dirname } });
 await runAllFixes(core);

--- a/docs/programmable-api.md
+++ b/docs/programmable-api.md
@@ -16,7 +16,9 @@ import { Core, takeRuleStatistics } from 'eslint-interactive';
 
 const core = new Core({
   patterns: ['fixtures'],
-  cwd: resolve('./github.com/mizdra/eslint-interactive'),
+  eslintOptions: {
+    cwd: resolve('./github.com/mizdra/eslint-interactive'),
+  },
 });
 const results = await core.lint();
 
@@ -91,11 +93,13 @@ import { Core, takeRuleStatistics } from 'eslint-interactive';
 
 const core = new Core({
   patterns: ['src'],
-  cwd: resolve('./github.com/mizdra/eslint-interactive'),
-  useEslintrc: false,
-  overrideConfig: {
-    rules: {
-      'sort-keys': 'error',
+  eslintOptions: {
+    cwd: resolve('./github.com/mizdra/eslint-interactive'),
+    useEslintrc: false,
+    overrideConfig: {
+      rules: {
+        'sort-keys': 'error',
+      },
     },
   },
 });

--- a/e2e-test/import-as-esm-from-esm/index.test.ts
+++ b/e2e-test/import-as-esm-from-esm/index.test.ts
@@ -19,7 +19,9 @@ afterEach(async () => {
 test('Programmable API', async () => {
   const core = new Core({
     patterns: ['fixtures-tmp'],
-    cwd: join(dirname(fileURLToPath(import.meta.url)), '..', '..'),
+    eslintOptions: {
+      cwd: join(dirname(fileURLToPath(import.meta.url)), '..', '..'),
+    },
   });
   const results = await core.lint();
 

--- a/src/cli/parse-argv.test.ts
+++ b/src/cli/parse-argv.test.ts
@@ -10,31 +10,43 @@ describe('parseArgv', () => {
     expect(parseArgv([...baseArgs, '1', 'true']).patterns).toStrictEqual(['1', 'true']);
   });
   test('--no-eslintrc', () => {
-    expect(parseArgv([...baseArgs, '--no-eslintrc']).useEslintrc).toStrictEqual(false);
-    expect(parseArgv([...baseArgs, '--no-eslintrc=false']).useEslintrc).toStrictEqual(true);
+    expect(parseArgv([...baseArgs, '--no-eslintrc']).eslintOptions?.useEslintrc).toStrictEqual(false);
+    expect(parseArgv([...baseArgs, '--no-eslintrc=false']).eslintOptions?.useEslintrc).toStrictEqual(true);
   });
   test('--config', () => {
-    expect(parseArgv([...baseArgs]).overrideConfigFile).toStrictEqual(undefined);
-    expect(parseArgv([...baseArgs, '--config', 'override-config-file.json']).overrideConfigFile).toStrictEqual(
-      'override-config-file.json',
-    );
+    expect(parseArgv([...baseArgs]).eslintOptions?.overrideConfigFile).toStrictEqual(undefined);
+    expect(
+      parseArgv([...baseArgs, '--config', 'override-config-file.json']).eslintOptions?.overrideConfigFile,
+    ).toStrictEqual('override-config-file.json');
   });
   test('--rulesdir', () => {
-    expect(parseArgv([...baseArgs, '--rulesdir', 'foo']).rulePaths).toStrictEqual(['foo']);
-    expect(parseArgv([...baseArgs, '--rulesdir', 'foo', '--rulesdir', 'bar']).rulePaths).toStrictEqual(['foo', 'bar']);
-    expect(parseArgv([...baseArgs, '--rulesdir', 'foo', 'bar']).rulePaths).toStrictEqual(['foo']);
-    expect(parseArgv([...baseArgs, '--rulesdir', '1', '--rulesdir', 'true']).rulePaths).toStrictEqual(['1', 'true']);
+    expect(parseArgv([...baseArgs, '--rulesdir', 'foo']).eslintOptions?.rulePaths).toStrictEqual(['foo']);
+    expect(parseArgv([...baseArgs, '--rulesdir', 'foo', '--rulesdir', 'bar']).eslintOptions?.rulePaths).toStrictEqual([
+      'foo',
+      'bar',
+    ]);
+    expect(parseArgv([...baseArgs, '--rulesdir', 'foo', 'bar']).eslintOptions?.rulePaths).toStrictEqual(['foo']);
+    expect(parseArgv([...baseArgs, '--rulesdir', '1', '--rulesdir', 'true']).eslintOptions?.rulePaths).toStrictEqual([
+      '1',
+      'true',
+    ]);
   });
   test('--ignore-path', () => {
-    expect(parseArgv([...baseArgs]).ignorePath).toStrictEqual(undefined);
-    expect(parseArgv([...baseArgs, '--ignore-path', 'foo']).ignorePath).toStrictEqual('foo');
+    expect(parseArgv([...baseArgs]).eslintOptions?.ignorePath).toStrictEqual(undefined);
+    expect(parseArgv([...baseArgs, '--ignore-path', 'foo']).eslintOptions?.ignorePath).toStrictEqual('foo');
   });
   test('--ext', () => {
-    expect(parseArgv([...baseArgs, '--ext', 'js']).extensions).toStrictEqual(['js']);
-    expect(parseArgv([...baseArgs, '--ext', 'js', '--ext', 'ts']).extensions).toStrictEqual(['js', 'ts']);
-    expect(parseArgv([...baseArgs, '--ext', 'js', 'ts']).extensions).toStrictEqual(['js']);
-    expect(parseArgv([...baseArgs, '--ext', 'js,ts,tsx']).extensions).toStrictEqual(['js', 'ts', 'tsx']);
-    expect(parseArgv([...baseArgs, '--ext', '1', '--ext', 'true']).extensions).toStrictEqual(['1', 'true']);
+    expect(parseArgv([...baseArgs, '--ext', 'js']).eslintOptions?.extensions).toStrictEqual(['js']);
+    expect(parseArgv([...baseArgs, '--ext', 'js', '--ext', 'ts']).eslintOptions?.extensions).toStrictEqual([
+      'js',
+      'ts',
+    ]);
+    expect(parseArgv([...baseArgs, '--ext', 'js', 'ts']).eslintOptions?.extensions).toStrictEqual(['js']);
+    expect(parseArgv([...baseArgs, '--ext', 'js,ts,tsx']).eslintOptions?.extensions).toStrictEqual(['js', 'ts', 'tsx']);
+    expect(parseArgv([...baseArgs, '--ext', '1', '--ext', 'true']).eslintOptions?.extensions).toStrictEqual([
+      '1',
+      'true',
+    ]);
   });
   test('--format', () => {
     expect(parseArgv([...baseArgs, '--format', 'foo']).formatterName).toBe('foo');
@@ -45,11 +57,13 @@ describe('parseArgv', () => {
     expect(parseArgv([...baseArgs, '--no-quiet']).quiet).toBe(false);
   });
   test('--cache', () => {
-    expect(parseArgv([...baseArgs, '--cache']).cache).toBe(true);
-    expect(parseArgv([...baseArgs, '--no-cache']).cache).toBe(false);
-    expect(parseArgv([...baseArgs, '--cache', 'false']).cache).toBe(false);
+    expect(parseArgv([...baseArgs, '--cache']).eslintOptions?.cache).toBe(true);
+    expect(parseArgv([...baseArgs, '--no-cache']).eslintOptions?.cache).toBe(false);
+    expect(parseArgv([...baseArgs, '--cache', 'false']).eslintOptions?.cache).toBe(false);
   });
   test('--cache-location', () => {
-    expect(parseArgv([...baseArgs, '--cache-location', '.eslintcache']).cacheLocation).toBe('.eslintcache');
+    expect(parseArgv([...baseArgs, '--cache-location', '.eslintcache']).eslintOptions?.cacheLocation).toBe(
+      '.eslintcache',
+    );
   });
 });

--- a/src/cli/parse-argv.ts
+++ b/src/cli/parse-argv.ts
@@ -1,5 +1,5 @@
 import yargs from 'yargs';
-import { Config, DEFAULT_BASE_CONFIG } from '../core.js';
+import { Config, configDefaults } from '../core.js';
 import { VERSION } from './package.js';
 
 /** Parse argv into the config object of eslint-interactive */
@@ -14,7 +14,7 @@ export function parseArgv(argv: string[]): Config {
     .option('eslintrc', {
       type: 'boolean',
       describe: 'Enable use of configuration from .eslintrc.*',
-      default: DEFAULT_BASE_CONFIG.useEslintrc,
+      default: configDefaults.eslintOptions.useEslintrc,
     })
     .option('config', {
       alias: 'c',
@@ -44,22 +44,22 @@ export function parseArgv(argv: string[]): Config {
     .option('format', {
       type: 'string',
       describe: 'Specify the format to be used for the `Display problem messages` action',
-      default: DEFAULT_BASE_CONFIG.formatterName,
+      default: configDefaults.formatterName,
     })
     .option('quiet', {
       type: 'boolean',
       describe: 'Report errors only',
-      default: DEFAULT_BASE_CONFIG.quiet,
+      default: configDefaults.quiet,
     })
     .option('cache', {
       type: 'boolean',
       describe: 'Only check changed files',
-      default: DEFAULT_BASE_CONFIG.cache,
+      default: configDefaults.eslintOptions.cache,
     })
     .option('cache-location', {
       type: 'string',
       describe: `Path to the cache file or directory`,
-      default: DEFAULT_BASE_CONFIG.cacheLocation,
+      default: configDefaults.eslintOptions.cacheLocation,
     })
     .example('$0 ./src', 'Lint ./src/ directory')
     .example('$0 ./src ./test', 'Lint multiple directories')
@@ -77,18 +77,19 @@ export function parseArgv(argv: string[]): Config {
     // map '.js,.ts' into ['.js', '.ts']
     .flatMap((extension) => extension.split(','));
   const formatterName = parsedArgv.format;
-  const resolvePluginsRelativeTo = parsedArgv['resolve-plugins-relative-to'];
   return {
     patterns,
-    useEslintrc: parsedArgv.eslintrc,
-    overrideConfigFile: parsedArgv.config,
-    extensions,
-    rulePaths,
-    ignorePath: parsedArgv.ignorePath,
+    eslintOptions: {
+      useEslintrc: parsedArgv.eslintrc,
+      overrideConfigFile: parsedArgv.config,
+      extensions,
+      rulePaths,
+      ignorePath: parsedArgv.ignorePath,
+      cache: parsedArgv.cache,
+      cacheLocation: parsedArgv['cache-location'],
+      resolvePluginsRelativeTo: parsedArgv['resolve-plugins-relative-to'],
+    },
     formatterName,
     quiet: parsedArgv.quiet,
-    cache: parsedArgv.cache,
-    cacheLocation: parsedArgv['cache-location'],
-    resolvePluginsRelativeTo,
   };
 }

--- a/src/core.ts
+++ b/src/core.ts
@@ -88,13 +88,13 @@ export const configDefaults = {
   eslintOptions: {
     useEslintrc: true,
     overrideConfigFile: undefined,
-    cwd: process.cwd(),
-    cache: true,
-    cacheLocation: relative(process.cwd(), join(getCacheDir(), '.eslintcache')),
     extensions: undefined,
     rulePaths: undefined,
     ignorePath: undefined,
+    cache: true,
+    cacheLocation: relative(process.cwd(), join(getCacheDir(), '.eslintcache')),
     overrideConfig: undefined,
+    cwd: process.cwd(),
     resolvePluginsRelativeTo: undefined,
   },
 } satisfies Partial<Config>;

--- a/src/core.ts
+++ b/src/core.ts
@@ -50,7 +50,7 @@ async function getUsedRuleIds(targetFilePaths: string[], options: ESLint.Options
 
 export type Undo = () => Promise<void>;
 
-type ESLintOptions = Pick<
+export type ESLintOptions = Pick<
   ESLint.Options,
   | 'useEslintrc'
   | 'overrideConfigFile'
@@ -82,7 +82,7 @@ type NormalizedConfig = {
 };
 
 /** Default config of `Core` */
-const configDefaults = {
+export const configDefaults = {
   formatterName: 'codeframe',
   quiet: false,
   eslintOptions: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
 export { run, type Options } from './cli/run.js';
-export { Core, type Config } from './core.js';
+export { Core, type Config, type ESLintOptions, configDefaults } from './core.js';
 export { takeRuleStatistics, type RuleStatistic } from './formatter/index.js';
 export { type FixableMaker, type SuggestionFilter, type FixContext } from './plugin/index.js';

--- a/src/test-util/fix-tester.ts
+++ b/src/test-util/fix-tester.ts
@@ -85,7 +85,7 @@ export class FixTester<T extends FixName> {
         'eslint-interactive': eslintInteractivePlugin,
       },
       overrideConfig: {
-        plugins: ['eslint-interactive', ...(this.defaultLinterConfig.plugins ?? [])],
+        plugins: ['eslint-interactive'],
         rules: {
           ...this.defaultLinterConfig.rules,
           ...options.rules,


### PR DESCRIPTION
This change is a first step towards resolving #283.

## New Features
- Expose `configDefaults` and `ESLintOptions`

## Breaking Changes
- Change options interface of `Core` class
  - `useEslintrc` replaced by `eslintOptions.useEslintrc`
  - `overrideConfigFile` replaced by `eslintOptions.overrideConfigFile`
  - `extensions` replaced by `eslintOptions.extensions`
  - `rulePaths` replaced by `eslintOptions.rulePaths`
  - `ignorePath` replaced by `eslintOptions.ignorePath`
  - `cache` replaced by `eslintOptions.cache`
  - `cacheLocation` replaced by `eslintOptions.cacheLocation`
  - `overrideConfig` replaced by `eslintOptions.overrideConfig`
  - `cwd` replaced by `eslintOptions.cwd`
  - `resolvePluginsRelativeTo` replaced by `eslintOptions.resolvePluginsRelativeTo`