### PR TITLE
refactor: Reuse same `ESLint` instance

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -48,6 +48,9 @@ module.exports = {
       parserOptions: {
         project: ['./tsconfig.json'],
       },
+      rules: {
+        '@typescript-eslint/naming-convention': 'off',
+      },
     },
     // for test
     {

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -104,4 +104,4 @@ jobs:
           # ref: https://github.com/mizdra/eslint-interactive/commit/b751cfdef788ac6eb6b39d2d015494123cae51c1#comments
           alert-threshold: '115%'
           # for test
-          # comment-always: true
+          comment-always: true

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -103,4 +103,4 @@ jobs:
           # ref: https://github.com/mizdra/eslint-interactive/commit/b751cfdef788ac6eb6b39d2d015494123cae51c1#comments
           alert-threshold: '115%'
           # for test
-          comment-always: true
+          # comment-always: true

--- a/.github/workflows/ci-node.yml
+++ b/.github/workflows/ci-node.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
   workflow_dispatch:
 
 permissions:

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "packageManager": "pnpm@8.9.0",
   "devDependencies": {
     "@mizdra/eslint-config-mizdra": "2.1.0-alpha.0",
+    "@mizdra/inline-fixture-files": "^1.0.0",
     "@mizdra/prettier-config-mizdra": "^1.0.0",
     "@tsconfig/node18": "^18.2.2",
     "@tsconfig/strictest": "^2.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,9 @@ importers:
       '@mizdra/eslint-config-mizdra':
         specifier: 2.1.0-alpha.0
         version: 2.1.0-alpha.0(eslint@8.53.0)(prettier@3.0.3)(typescript@5.2.2)
+      '@mizdra/inline-fixture-files':
+        specifier: ^1.0.0
+        version: 1.0.0
       '@mizdra/prettier-config-mizdra':
         specifier: ^1.0.0
         version: 1.0.0(prettier@3.0.3)
@@ -465,6 +468,11 @@ packages:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
+    dev: true
+
+  /@mizdra/inline-fixture-files@1.0.0:
+    resolution: {integrity: sha512-R+KK0jQGH3EDl4LlnqP85M4+14j3r3qHxIC0iwj8DodZI7EI4w/L1pwnWTyjZulmXWkih+BtF+EzIyjHPrUIZA==}
+    engines: {node: '>=16.0.0'}
     dev: true
 
   /@mizdra/prettier-config-mizdra@1.0.0(prettier@3.0.3):

--- a/src/test-util/fixtures.ts
+++ b/src/test-util/fixtures.ts
@@ -1,13 +1,20 @@
 import { exec } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
 import { rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { promisify } from 'node:util';
+import { defineIFFCreator } from '@mizdra/inline-fixture-files';
 import fse from 'fs-extra/esm';
 
 const execPromise = promisify(exec);
 
 const cwd = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+const fixtureDir = join(tmpdir(), 'eslint-interactive', process.env['VITEST_POOL_ID']!);
+export const createIFF = defineIFFCreator({ generateRootDir: () => join(fixtureDir, randomUUID()) });
 
 /**
  * Returns a string containing the stitched together contents of the file modified by fix.

--- a/src/util/eslint.test.ts
+++ b/src/util/eslint.test.ts
@@ -3,7 +3,6 @@ import { SourceLocation } from 'estree';
 import { describe, expect, test } from 'vitest';
 import { fakeLintMessage, fakeLintResult } from '../test-util/eslint.js';
 import {
-  scanUsedPluginsFromResults,
   parseDisableComment,
   findShebang,
   filterResultsByRuleId,
@@ -16,20 +15,6 @@ import {
 
 const range: [number, number] = [0, 1];
 const loc: SourceLocation = { start: { line: 1, column: 0 }, end: { line: 1, column: 1 } };
-
-test('scanUsedPluginsFromResults', () => {
-  const results: ESLint.LintResult[] = [
-    fakeLintResult({
-      messages: [
-        fakeLintMessage({ ruleId: 'rule', severity: 2 }),
-        fakeLintMessage({ ruleId: 'plugin/rule', severity: 2 }),
-        fakeLintMessage({ ruleId: '@scoped/plugin/rule', severity: 2 }),
-        fakeLintMessage({ ruleId: 'invalid/@scoped/plugin/rule', severity: 2 }),
-      ],
-    }),
-  ];
-  expect(scanUsedPluginsFromResults(results)).toStrictEqual(['plugin', '@scoped/plugin']);
-});
 
 test('filterResultsByRuleId', () => {
   const results: ESLint.LintResult[] = [

--- a/src/util/eslint.ts
+++ b/src/util/eslint.ts
@@ -1,30 +1,11 @@
 import { AST, ESLint, Linter, Rule, SourceCode } from 'eslint';
 import type { Comment, SourceLocation } from 'estree';
 import { unique } from './array.js';
-import { notEmpty } from './type-check.js';
 
 const COMMENT_RE =
   /^\s*(?<header>eslint-disable|eslint-disable-next-line)\s+(?<ruleList>[@a-z0-9\-_$/]*(?:\s*,\s*[@a-z0-9\-_$/]*)*(?:\s*,)?)(?:\s+--\s+(?<description>.*\S))?\s*$/u;
 
 const SHEBANG_PATTERN = /^#!.+?\r?\n/u;
-
-/** `results` 内で使われているプラグインの名前のリストを洗い出して返す */
-export function scanUsedPluginsFromResults(results: ESLint.LintResult[]): string[] {
-  const plugins = results
-    .flatMap((result) => result.messages) // messages: Linter.LintMessage[]
-    .map((message) => message.ruleId) // ruleIds: (string | undefined)[]
-    .filter(notEmpty) // ruleIds: string[]
-    .map((ruleId) => {
-      const parts = ruleId.split('/');
-      if (parts.length === 1) return undefined; // ex: 'rule-a'
-      if (parts.length === 2) return parts[0]; // ex: 'plugin/rule-a'
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      if (parts.length === 3) return `${parts[0]!}/${parts[1]!}`; // ex: '@scoped/plugin/rule-a'
-      return undefined; // invalid ruleId
-    }) // plugins: string[]
-    .filter(notEmpty);
-  return unique(plugins);
-}
 
 export type DisableComment = {
   type: 'Block' | 'Line';


### PR DESCRIPTION
This change is a second step towards resolving #283.