### PR TITLE
Change options interface

### DIFF
--- a/benchmark/run-cachegrind-benchmarking.js
+++ b/benchmark/run-cachegrind-benchmarking.js
@@ -5,5 +5,5 @@ import { Core } from '../dist/core.js';
 
 const __dirname = join(dirname(fileURLToPath(import.meta.url)));
 
-const core = new Core({ patterns: ['fixtures'], eslintOptions: { cwd: __dirname } });
+const core = new Core({ patterns: ['fixtures'], cwd: __dirname, eslintOptions: { type: 'eslintrc' } });
 await runAllFixes(core);

--- a/docs/programmable-api.md
+++ b/docs/programmable-api.md
@@ -16,8 +16,9 @@ import { Core, takeRuleStatistics } from 'eslint-interactive';
 
 const core = new Core({
   patterns: ['fixtures'],
+  cwd: resolve('./github.com/mizdra/eslint-interactive'),
   eslintOptions: {
-    cwd: resolve('./github.com/mizdra/eslint-interactive'),
+    type: 'eslintrc',
   },
 });
 const results = await core.lint();
@@ -93,8 +94,9 @@ import { Core, takeRuleStatistics } from 'eslint-interactive';
 
 const core = new Core({
   patterns: ['src'],
+  cwd: resolve('./github.com/mizdra/eslint-interactive'),
   eslintOptions: {
-    cwd: resolve('./github.com/mizdra/eslint-interactive'),
+    type: 'eslintrc',
     useEslintrc: false,
     overrideConfig: {
       rules: {

--- a/src/cli/parse-argv.test.ts
+++ b/src/cli/parse-argv.test.ts
@@ -10,43 +10,31 @@ describe('parseArgv', () => {
     expect(parseArgv([...baseArgs, '1', 'true']).patterns).toStrictEqual(['1', 'true']);
   });
   test('--no-eslintrc', () => {
-    expect(parseArgv([...baseArgs, '--no-eslintrc']).eslintOptions?.useEslintrc).toStrictEqual(false);
-    expect(parseArgv([...baseArgs, '--no-eslintrc=false']).eslintOptions?.useEslintrc).toStrictEqual(true);
+    expect(parseArgv([...baseArgs, '--no-eslintrc']).useEslintrc).toStrictEqual(false);
+    expect(parseArgv([...baseArgs, '--no-eslintrc=false']).useEslintrc).toStrictEqual(true);
   });
   test('--config', () => {
-    expect(parseArgv([...baseArgs]).eslintOptions?.overrideConfigFile).toStrictEqual(undefined);
-    expect(
-      parseArgv([...baseArgs, '--config', 'override-config-file.json']).eslintOptions?.overrideConfigFile,
-    ).toStrictEqual('override-config-file.json');
+    expect(parseArgv([...baseArgs]).overrideConfigFile).toStrictEqual(undefined);
+    expect(parseArgv([...baseArgs, '--config', 'override-config-file.json']).overrideConfigFile).toStrictEqual(
+      'override-config-file.json',
+    );
   });
   test('--rulesdir', () => {
-    expect(parseArgv([...baseArgs, '--rulesdir', 'foo']).eslintOptions?.rulePaths).toStrictEqual(['foo']);
-    expect(parseArgv([...baseArgs, '--rulesdir', 'foo', '--rulesdir', 'bar']).eslintOptions?.rulePaths).toStrictEqual([
-      'foo',
-      'bar',
-    ]);
-    expect(parseArgv([...baseArgs, '--rulesdir', 'foo', 'bar']).eslintOptions?.rulePaths).toStrictEqual(['foo']);
-    expect(parseArgv([...baseArgs, '--rulesdir', '1', '--rulesdir', 'true']).eslintOptions?.rulePaths).toStrictEqual([
-      '1',
-      'true',
-    ]);
+    expect(parseArgv([...baseArgs, '--rulesdir', 'foo']).rulePaths).toStrictEqual(['foo']);
+    expect(parseArgv([...baseArgs, '--rulesdir', 'foo', '--rulesdir', 'bar']).rulePaths).toStrictEqual(['foo', 'bar']);
+    expect(parseArgv([...baseArgs, '--rulesdir', 'foo', 'bar']).rulePaths).toStrictEqual(['foo']);
+    expect(parseArgv([...baseArgs, '--rulesdir', '1', '--rulesdir', 'true']).rulePaths).toStrictEqual(['1', 'true']);
   });
   test('--ignore-path', () => {
-    expect(parseArgv([...baseArgs]).eslintOptions?.ignorePath).toStrictEqual(undefined);
-    expect(parseArgv([...baseArgs, '--ignore-path', 'foo']).eslintOptions?.ignorePath).toStrictEqual('foo');
+    expect(parseArgv([...baseArgs]).ignorePath).toStrictEqual(undefined);
+    expect(parseArgv([...baseArgs, '--ignore-path', 'foo']).ignorePath).toStrictEqual('foo');
   });
   test('--ext', () => {
-    expect(parseArgv([...baseArgs, '--ext', 'js']).eslintOptions?.extensions).toStrictEqual(['js']);
-    expect(parseArgv([...baseArgs, '--ext', 'js', '--ext', 'ts']).eslintOptions?.extensions).toStrictEqual([
-      'js',
-      'ts',
-    ]);
-    expect(parseArgv([...baseArgs, '--ext', 'js', 'ts']).eslintOptions?.extensions).toStrictEqual(['js']);
-    expect(parseArgv([...baseArgs, '--ext', 'js,ts,tsx']).eslintOptions?.extensions).toStrictEqual(['js', 'ts', 'tsx']);
-    expect(parseArgv([...baseArgs, '--ext', '1', '--ext', 'true']).eslintOptions?.extensions).toStrictEqual([
-      '1',
-      'true',
-    ]);
+    expect(parseArgv([...baseArgs, '--ext', 'js']).extensions).toStrictEqual(['js']);
+    expect(parseArgv([...baseArgs, '--ext', 'js', '--ext', 'ts']).extensions).toStrictEqual(['js', 'ts']);
+    expect(parseArgv([...baseArgs, '--ext', 'js', 'ts']).extensions).toStrictEqual(['js']);
+    expect(parseArgv([...baseArgs, '--ext', 'js,ts,tsx']).extensions).toStrictEqual(['js', 'ts', 'tsx']);
+    expect(parseArgv([...baseArgs, '--ext', '1', '--ext', 'true']).extensions).toStrictEqual(['1', 'true']);
   });
   test('--format', () => {
     expect(parseArgv([...baseArgs, '--format', 'foo']).formatterName).toBe('foo');
@@ -57,13 +45,11 @@ describe('parseArgv', () => {
     expect(parseArgv([...baseArgs, '--no-quiet']).quiet).toBe(false);
   });
   test('--cache', () => {
-    expect(parseArgv([...baseArgs, '--cache']).eslintOptions?.cache).toBe(true);
-    expect(parseArgv([...baseArgs, '--no-cache']).eslintOptions?.cache).toBe(false);
-    expect(parseArgv([...baseArgs, '--cache', 'false']).eslintOptions?.cache).toBe(false);
+    expect(parseArgv([...baseArgs, '--cache']).cache).toBe(true);
+    expect(parseArgv([...baseArgs, '--no-cache']).cache).toBe(false);
+    expect(parseArgv([...baseArgs, '--cache', 'false']).cache).toBe(false);
   });
   test('--cache-location', () => {
-    expect(parseArgv([...baseArgs, '--cache-location', '.eslintcache']).eslintOptions?.cacheLocation).toBe(
-      '.eslintcache',
-    );
+    expect(parseArgv([...baseArgs, '--cache-location', '.eslintcache']).cacheLocation).toBe('.eslintcache');
   });
 });

--- a/src/cli/parse-argv.ts
+++ b/src/cli/parse-argv.ts
@@ -115,6 +115,7 @@ export function translateCLIOptions(options: ParsedCLIOptions, eslintOptionsType
       formatterName: options.formatterName,
       quiet: options.quiet,
       eslintOptions: {
+        type: 'eslintrc',
         useEslintrc: options.useEslintrc,
         overrideConfigFile: options.overrideConfigFile,
         extensions: options.extensions,

--- a/src/cli/parse-argv.ts
+++ b/src/cli/parse-argv.ts
@@ -1,11 +1,13 @@
+import { join, relative } from 'node:path';
 import yargs from 'yargs';
-import { configDefaults } from '../config.js';
+import { getCacheDir } from '../util/cache.js';
+import { DeepPartial } from '../util/type-check.js';
 import { VERSION } from './package.js';
 
 export type ParsedCLIOptions = {
   patterns: string[];
-  formatterName: string;
-  quiet: boolean;
+  formatterName: string | undefined;
+  quiet: boolean | undefined;
   useEslintrc: boolean | undefined;
   overrideConfigFile: string | undefined;
   extensions: string[] | undefined;
@@ -15,6 +17,15 @@ export type ParsedCLIOptions = {
   cacheLocation: string | undefined;
   resolvePluginsRelativeTo: string | undefined;
 };
+
+/** Default CLI Options */
+export const cliOptionsDefaults = {
+  formatterName: 'codeframe',
+  quiet: false,
+  useEslintrc: true,
+  cache: true,
+  cacheLocation: relative(process.cwd(), join(getCacheDir(), '.eslintcache')),
+} satisfies DeepPartial<ParsedCLIOptions>;
 
 /** Parse CLI options */
 export function parseArgv(argv: string[]): ParsedCLIOptions {
@@ -28,7 +39,7 @@ export function parseArgv(argv: string[]): ParsedCLIOptions {
     .option('eslintrc', {
       type: 'boolean',
       describe: 'Enable use of configuration from .eslintrc.*',
-      default: configDefaults.eslintOptions.useEslintrc,
+      default: cliOptionsDefaults.useEslintrc,
     })
     .option('config', {
       alias: 'c',
@@ -58,22 +69,22 @@ export function parseArgv(argv: string[]): ParsedCLIOptions {
     .option('format', {
       type: 'string',
       describe: 'Specify the format to be used for the `Display problem messages` action',
-      default: configDefaults.formatterName,
+      default: cliOptionsDefaults.formatterName,
     })
     .option('quiet', {
       type: 'boolean',
       describe: 'Report errors only',
-      default: configDefaults.quiet,
+      default: cliOptionsDefaults.quiet,
     })
     .option('cache', {
       type: 'boolean',
       describe: 'Only check changed files',
-      default: configDefaults.eslintOptions.cache,
+      default: cliOptionsDefaults.cache,
     })
     .option('cache-location', {
       type: 'string',
       describe: `Path to the cache file or directory`,
-      default: configDefaults.eslintOptions.cacheLocation,
+      default: cliOptionsDefaults.cacheLocation,
     })
     .example('$0 ./src', 'Lint ./src/ directory')
     .example('$0 ./src ./test', 'Lint multiple directories')

--- a/src/cli/parse-argv.ts
+++ b/src/cli/parse-argv.ts
@@ -1,8 +1,8 @@
 import yargs from 'yargs';
-import { Config, configDefaults } from '../core.js';
+import { configDefaults } from '../config.js';
 import { VERSION } from './package.js';
 
-type ParsedCLIOptions = {
+export type ParsedCLIOptions = {
   patterns: string[];
   formatterName: string;
   quiet: boolean;
@@ -104,31 +104,4 @@ export function parseArgv(argv: string[]): ParsedCLIOptions {
     cacheLocation: parsedArgv['cache-location'],
     resolvePluginsRelativeTo: parsedArgv['resolve-plugins-relative-to'],
   };
-}
-
-type ESLintOptionsType = 'eslintrc' | 'flat';
-
-export function translateCLIOptions(options: ParsedCLIOptions, eslintOptionsType: ESLintOptionsType): Config {
-  if (eslintOptionsType === 'eslintrc') {
-    return {
-      patterns: options.patterns,
-      formatterName: options.formatterName,
-      quiet: options.quiet,
-      eslintOptions: {
-        type: 'eslintrc',
-        useEslintrc: options.useEslintrc,
-        overrideConfigFile: options.overrideConfigFile,
-        extensions: options.extensions,
-        rulePaths: options.rulePaths,
-        ignorePath: options.ignorePath,
-        cache: options.cache,
-        cacheLocation: options.cacheLocation,
-        resolvePluginsRelativeTo: options.resolvePluginsRelativeTo,
-      },
-    };
-  } else if (eslintOptionsType === 'flat') {
-    throw new Error('Flat config is not supported yet');
-  } else {
-    throw new Error(`Unexpected configType: ${String(eslintOptionsType)}`);
-  }
 }

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -6,7 +6,7 @@ import nodeEndpoint from 'comlink/dist/esm/node-adapter.mjs';
 import isInstalledGlobally from 'is-installed-globally';
 import terminalLink from 'terminal-link';
 import { warn } from '../cli/log.js';
-import { parseArgv } from '../cli/parse-argv.js';
+import { parseArgv, translateCLIOptions } from '../cli/parse-argv.js';
 import { SerializableCore } from '../core-worker.js';
 import { lint, selectAction, selectRuleIds, checkResults, NextScene } from '../scene/index.js';
 
@@ -25,7 +25,8 @@ export async function run(options: Options) {
         'It is recommended to install eslint-interactive locally.',
     );
   }
-  const config = parseArgv(options.argv);
+  const parsedCLIOptions = parseArgv(options.argv);
+  const config = translateCLIOptions(parsedCLIOptions, 'eslintrc'); // TODO: support flat config
 
   // Directly executing the Core API will hog the main thread and halt the spinner.
   // So we wrap it with comlink and run it on the Worker.

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -6,7 +6,8 @@ import nodeEndpoint from 'comlink/dist/esm/node-adapter.mjs';
 import isInstalledGlobally from 'is-installed-globally';
 import terminalLink from 'terminal-link';
 import { warn } from '../cli/log.js';
-import { parseArgv, translateCLIOptions } from '../cli/parse-argv.js';
+import { parseArgv } from '../cli/parse-argv.js';
+import { translateCLIOptions } from '../config.js';
 import { SerializableCore } from '../core-worker.js';
 import { lint, selectAction, selectRuleIds, checkResults, NextScene } from '../scene/index.js';
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,7 +1,5 @@
-import { join, relative } from 'node:path';
 import { ESLint } from 'eslint';
-import { ParsedCLIOptions } from './cli/parse-argv.js';
-import { getCacheDir } from './util/cache.js';
+import { cliOptionsDefaults, ParsedCLIOptions } from './cli/parse-argv.js';
 import { DeepPartial } from './util/type-check.js';
 
 export type ESLintrcESLintOptions = { type: 'eslintrc' } & Pick<
@@ -58,17 +56,17 @@ export function translateCLIOptions(options: ParsedCLIOptions, eslintOptionsType
 
 /** Default config of `Core` */
 export const configDefaults = {
-  formatterName: 'codeframe',
-  quiet: false,
+  formatterName: cliOptionsDefaults.formatterName,
+  quiet: cliOptionsDefaults.quiet,
   cwd: process.cwd(),
   eslintOptions: {
-    useEslintrc: true,
+    useEslintrc: cliOptionsDefaults.useEslintrc,
     overrideConfigFile: undefined,
     extensions: undefined,
     rulePaths: undefined,
     ignorePath: undefined,
-    cache: true,
-    cacheLocation: relative(process.cwd(), join(getCacheDir(), '.eslintcache')),
+    cache: cliOptionsDefaults.cache,
+    cacheLocation: cliOptionsDefaults.cacheLocation,
     overrideConfig: undefined,
     resolvePluginsRelativeTo: undefined,
   },

--- a/src/config.ts
+++ b/src/config.ts
@@ -29,24 +29,6 @@ export type Config = {
   eslintOptions: ESLintOptions;
 };
 
-/** Default config of `Core` */
-export const configDefaults = {
-  formatterName: 'codeframe',
-  quiet: false,
-  cwd: process.cwd(),
-  eslintOptions: {
-    useEslintrc: true,
-    overrideConfigFile: undefined,
-    extensions: undefined,
-    rulePaths: undefined,
-    ignorePath: undefined,
-    cache: true,
-    cacheLocation: relative(process.cwd(), join(getCacheDir(), '.eslintcache')),
-    overrideConfig: undefined,
-    resolvePluginsRelativeTo: undefined,
-  },
-} satisfies DeepPartial<Config>;
-
 type ESLintOptionsType = 'eslintrc' | 'flat';
 
 export function translateCLIOptions(options: ParsedCLIOptions, eslintOptionsType: ESLintOptionsType): Config {
@@ -72,4 +54,54 @@ export function translateCLIOptions(options: ParsedCLIOptions, eslintOptionsType
   } else {
     throw new Error(`Unexpected configType: ${String(eslintOptionsType)}`);
   }
+}
+
+/** Default config of `Core` */
+export const configDefaults = {
+  formatterName: 'codeframe',
+  quiet: false,
+  cwd: process.cwd(),
+  eslintOptions: {
+    useEslintrc: true,
+    overrideConfigFile: undefined,
+    extensions: undefined,
+    rulePaths: undefined,
+    ignorePath: undefined,
+    cache: true,
+    cacheLocation: relative(process.cwd(), join(getCacheDir(), '.eslintcache')),
+    overrideConfig: undefined,
+    resolvePluginsRelativeTo: undefined,
+  },
+} satisfies DeepPartial<Config>;
+
+export type NormalizedConfig = {
+  patterns: string[];
+  formatterName: string;
+  quiet: boolean;
+  cwd: string;
+  eslintOptions: ESLintOptions;
+};
+
+export function normalizeConfig(config: Config): NormalizedConfig {
+  const cwd = config.cwd ?? configDefaults.cwd;
+  return {
+    patterns: config.patterns,
+    formatterName: config.formatterName ?? configDefaults.formatterName,
+    quiet: config.quiet ?? configDefaults.quiet,
+    cwd,
+    eslintOptions: {
+      type: 'eslintrc',
+      useEslintrc: config.eslintOptions.useEslintrc ?? configDefaults.eslintOptions.useEslintrc,
+      overrideConfigFile: config.eslintOptions.overrideConfigFile ?? configDefaults.eslintOptions.overrideConfigFile,
+      extensions: config.eslintOptions.extensions ?? configDefaults.eslintOptions.extensions,
+      rulePaths: config.eslintOptions.rulePaths ?? configDefaults.eslintOptions.rulePaths,
+      ignorePath: config.eslintOptions.ignorePath ?? configDefaults.eslintOptions.ignorePath,
+      cache: config.eslintOptions.cache ?? configDefaults.eslintOptions.cache,
+      cacheLocation: config.eslintOptions.cacheLocation ?? configDefaults.eslintOptions.cacheLocation,
+      overrideConfig: config.eslintOptions.overrideConfig ?? configDefaults.eslintOptions.overrideConfig,
+      cwd,
+      resolvePluginsRelativeTo:
+        config.eslintOptions.resolvePluginsRelativeTo ?? configDefaults.eslintOptions.resolvePluginsRelativeTo,
+    },
+  };
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,75 @@
+import { join, relative } from 'node:path';
+import { ESLint } from 'eslint';
+import { ParsedCLIOptions } from './cli/parse-argv.js';
+import { getCacheDir } from './util/cache.js';
+import { DeepPartial } from './util/type-check.js';
+
+export type ESLintrcESLintOptions = { type: 'eslintrc' } & Pick<
+  ESLint.Options,
+  | 'useEslintrc'
+  | 'overrideConfigFile'
+  | 'extensions'
+  | 'rulePaths'
+  | 'ignorePath'
+  | 'cache'
+  | 'cacheLocation'
+  | 'overrideConfig'
+  | 'cwd'
+  | 'resolvePluginsRelativeTo'
+>;
+
+export type ESLintOptions = ESLintrcESLintOptions; // TODO: support flat config
+
+/** The config of eslint-interactive */
+export type Config = {
+  patterns: string[];
+  formatterName?: string | undefined;
+  quiet?: boolean | undefined;
+  cwd?: string | undefined;
+  eslintOptions: ESLintOptions;
+};
+
+/** Default config of `Core` */
+export const configDefaults = {
+  formatterName: 'codeframe',
+  quiet: false,
+  cwd: process.cwd(),
+  eslintOptions: {
+    useEslintrc: true,
+    overrideConfigFile: undefined,
+    extensions: undefined,
+    rulePaths: undefined,
+    ignorePath: undefined,
+    cache: true,
+    cacheLocation: relative(process.cwd(), join(getCacheDir(), '.eslintcache')),
+    overrideConfig: undefined,
+    resolvePluginsRelativeTo: undefined,
+  },
+} satisfies DeepPartial<Config>;
+
+type ESLintOptionsType = 'eslintrc' | 'flat';
+
+export function translateCLIOptions(options: ParsedCLIOptions, eslintOptionsType: ESLintOptionsType): Config {
+  if (eslintOptionsType === 'eslintrc') {
+    return {
+      patterns: options.patterns,
+      formatterName: options.formatterName,
+      quiet: options.quiet,
+      eslintOptions: {
+        type: 'eslintrc',
+        useEslintrc: options.useEslintrc,
+        overrideConfigFile: options.overrideConfigFile,
+        extensions: options.extensions,
+        rulePaths: options.rulePaths,
+        ignorePath: options.ignorePath,
+        cache: options.cache,
+        cacheLocation: options.cacheLocation,
+        resolvePluginsRelativeTo: options.resolvePluginsRelativeTo,
+      },
+    };
+  } else if (eslintOptionsType === 'flat') {
+    throw new Error('Flat config is not supported yet');
+  } else {
+    throw new Error(`Unexpected configType: ${String(eslintOptionsType)}`);
+  }
+}

--- a/src/core-worker.ts
+++ b/src/core-worker.ts
@@ -2,7 +2,8 @@ import { parentPort } from 'node:worker_threads';
 import { expose, proxy } from 'comlink';
 import nodeEndpoint from 'comlink/dist/esm/node-adapter.mjs';
 import { ESLint } from 'eslint';
-import { Core, Config } from './core.js';
+import { Config } from './config.js';
+import { Core } from './core.js';
 import { FixableMaker, SuggestionFilter } from './plugin/index.js';
 
 /**

--- a/src/core.test.ts
+++ b/src/core.test.ts
@@ -87,7 +87,7 @@ describe('Core', () => {
         cwd: iff.rootDir,
       },
     });
-    expect(core1.config.eslintOptions).toStrictEqual({
+    expect(core1.eslintOptions).toStrictEqual({
       type: 'eslintrc',
       useEslintrc: false,
       overrideConfigFile: 'override-config-file.json',
@@ -106,7 +106,10 @@ describe('Core', () => {
         type: 'eslintrc',
       },
     });
-    expect(core2.config.eslintOptions).toStrictEqual(configDefaults.eslintOptions);
+    expect(core2.eslintOptions).toStrictEqual({
+      type: 'eslintrc',
+      ...configDefaults.eslintOptions,
+    });
   });
   describe('lint', () => {
     test('returns lint results', async () => {
@@ -115,14 +118,14 @@ describe('Core', () => {
     });
     test('filters warnings with --quiet option', async () => {
       const coreWithoutQuiet = new Core({
-        ...core.config,
+        ...core,
         quiet: false,
       });
       const resultsWithoutQuiet = await coreWithoutQuiet.lint();
       expect(countWarnings(resultsWithoutQuiet)).not.toEqual(0);
 
       const coreWithQuiet = new Core({
-        ...core.config,
+        ...core,
         quiet: true,
       });
       const resultsWithQuiet = await coreWithQuiet.lint();
@@ -130,15 +133,15 @@ describe('Core', () => {
     });
     test('ignores files with --ignore-path option', async () => {
       const coreWithoutIgnorePath = new Core({
-        ...core.config,
+        ...core,
       });
       const resultsWithoutIgnorePath = await coreWithoutIgnorePath.lint();
       expect(countWarnings(resultsWithoutIgnorePath)).not.toEqual(0);
 
       const coreWithIgnorePath = new Core({
-        ...core.config,
+        ...core,
         eslintOptions: {
-          ...core.config.eslintOptions,
+          ...core.eslintOptions,
           ignorePath: 'fixtures-tmp/.customignore',
         },
       });
@@ -232,9 +235,9 @@ describe('Core', () => {
   describe('with overrideConfig', () => {
     test('returns lint results', async () => {
       const coreWithOverride = new Core({
-        ...core.config,
+        ...core,
         eslintOptions: {
-          ...core.config.eslintOptions,
+          ...core.eslintOptions,
           useEslintrc: false,
           overrideConfig: {
             root: true,

--- a/src/core.test.ts
+++ b/src/core.test.ts
@@ -59,11 +59,11 @@ describe('Core', () => {
     core = new Core({
       patterns: ['fixtures-tmp'],
       formatterName,
+      cwd,
       eslintOptions: {
         type: 'eslintrc',
         rulePaths: ['fixtures-tmp/rules'],
         extensions: ['.js', '.jsx', '.mjs'],
-        cwd,
       },
     });
   });
@@ -76,6 +76,7 @@ describe('Core', () => {
     const core1 = new Core({
       patterns: ['pattern-a', 'pattern-b'],
       formatterName,
+      cwd: iff.rootDir,
       eslintOptions: {
         type: 'eslintrc',
         useEslintrc: false,
@@ -84,7 +85,6 @@ describe('Core', () => {
         extensions: ['.js', '.jsx'],
         cache: false,
         cacheLocation: '.eslintcache',
-        cwd: iff.rootDir,
       },
     });
     expect(core1.eslintOptions).toStrictEqual({
@@ -107,8 +107,9 @@ describe('Core', () => {
       },
     });
     expect(core2.eslintOptions).toStrictEqual({
-      type: 'eslintrc',
       ...configDefaults.eslintOptions,
+      type: 'eslintrc',
+      cwd: process.cwd(),
     });
   });
   describe('lint', () => {

--- a/src/core.test.ts
+++ b/src/core.test.ts
@@ -60,6 +60,7 @@ describe('Core', () => {
       patterns: ['fixtures-tmp'],
       formatterName,
       eslintOptions: {
+        type: 'eslintrc',
         rulePaths: ['fixtures-tmp/rules'],
         extensions: ['.js', '.jsx', '.mjs'],
         cwd,
@@ -76,6 +77,7 @@ describe('Core', () => {
       patterns: ['pattern-a', 'pattern-b'],
       formatterName,
       eslintOptions: {
+        type: 'eslintrc',
         useEslintrc: false,
         overrideConfigFile: 'override-config-file.json',
         rulePaths: ['rule-path-a'],
@@ -85,7 +87,8 @@ describe('Core', () => {
         cwd: iff.rootDir,
       },
     });
-    expect(core1.config.eslintOptions).toStrictEqual<ESLint.Options>({
+    expect(core1.config.eslintOptions).toStrictEqual({
+      type: 'eslintrc',
       useEslintrc: false,
       overrideConfigFile: 'override-config-file.json',
       cache: false,
@@ -99,8 +102,11 @@ describe('Core', () => {
     });
     const core2 = new Core({
       patterns: ['pattern-a', 'pattern-b'],
+      eslintOptions: {
+        type: 'eslintrc',
+      },
     });
-    expect(core2.config.eslintOptions).toStrictEqual<ESLint.Options>(configDefaults.eslintOptions);
+    expect(core2.config.eslintOptions).toStrictEqual(configDefaults.eslintOptions);
   });
   describe('lint', () => {
     test('returns lint results', async () => {

--- a/src/core.test.ts
+++ b/src/core.test.ts
@@ -3,7 +3,8 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { ESLint, Linter } from 'eslint';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
-import { Core, configDefaults } from './core.js';
+import { configDefaults } from './config.js';
+import { Core } from './core.js';
 import { cleanupFixturesCopy, createIFF, getSnapshotOfChangedFiles, setupFixturesCopy } from './test-util/fixtures.js';
 
 const testIf = (condition: boolean) => (condition ? test : test.skip);

--- a/src/core.test.ts
+++ b/src/core.test.ts
@@ -88,7 +88,7 @@ describe('Core', () => {
         cacheLocation: '.eslintcache',
       },
     });
-    expect(core1.eslintOptions).toStrictEqual({
+    expect(core1.config.eslintOptions).toStrictEqual({
       type: 'eslintrc',
       useEslintrc: false,
       overrideConfigFile: 'override-config-file.json',
@@ -107,7 +107,7 @@ describe('Core', () => {
         type: 'eslintrc',
       },
     });
-    expect(core2.eslintOptions).toStrictEqual({
+    expect(core2.config.eslintOptions).toStrictEqual({
       ...configDefaults.eslintOptions,
       type: 'eslintrc',
       cwd: process.cwd(),
@@ -120,14 +120,14 @@ describe('Core', () => {
     });
     test('filters warnings with --quiet option', async () => {
       const coreWithoutQuiet = new Core({
-        ...core,
+        ...core.config,
         quiet: false,
       });
       const resultsWithoutQuiet = await coreWithoutQuiet.lint();
       expect(countWarnings(resultsWithoutQuiet)).not.toEqual(0);
 
       const coreWithQuiet = new Core({
-        ...core,
+        ...core.config,
         quiet: true,
       });
       const resultsWithQuiet = await coreWithQuiet.lint();
@@ -135,15 +135,15 @@ describe('Core', () => {
     });
     test('ignores files with --ignore-path option', async () => {
       const coreWithoutIgnorePath = new Core({
-        ...core,
+        ...core.config,
       });
       const resultsWithoutIgnorePath = await coreWithoutIgnorePath.lint();
       expect(countWarnings(resultsWithoutIgnorePath)).not.toEqual(0);
 
       const coreWithIgnorePath = new Core({
-        ...core,
+        ...core.config,
         eslintOptions: {
-          ...core.eslintOptions,
+          ...core.config.eslintOptions,
           ignorePath: 'fixtures-tmp/.customignore',
         },
       });
@@ -237,9 +237,9 @@ describe('Core', () => {
   describe('with overrideConfig', () => {
     test('returns lint results', async () => {
       const coreWithOverride = new Core({
-        ...core,
+        ...core.config,
         eslintOptions: {
-          ...core.eslintOptions,
+          ...core.config.eslintOptions,
           useEslintrc: false,
           overrideConfig: {
             root: true,

--- a/src/core.ts
+++ b/src/core.ts
@@ -110,17 +110,17 @@ export class Core {
     this.cwd = config.cwd ?? configDefaults.cwd;
     this.eslintOptions = {
       type: 'eslintrc',
-      useEslintrc: config.eslintOptions?.useEslintrc ?? configDefaults.eslintOptions.useEslintrc,
-      overrideConfigFile: config.eslintOptions?.overrideConfigFile ?? configDefaults.eslintOptions.overrideConfigFile,
-      extensions: config.eslintOptions?.extensions ?? configDefaults.eslintOptions.extensions,
-      rulePaths: config.eslintOptions?.rulePaths ?? configDefaults.eslintOptions.rulePaths,
-      ignorePath: config.eslintOptions?.ignorePath ?? configDefaults.eslintOptions.ignorePath,
-      cache: config.eslintOptions?.cache ?? configDefaults.eslintOptions.cache,
-      cacheLocation: config.eslintOptions?.cacheLocation ?? configDefaults.eslintOptions.cacheLocation,
-      overrideConfig: config.eslintOptions?.overrideConfig ?? configDefaults.eslintOptions.overrideConfig,
+      useEslintrc: config.eslintOptions.useEslintrc ?? configDefaults.eslintOptions.useEslintrc,
+      overrideConfigFile: config.eslintOptions.overrideConfigFile ?? configDefaults.eslintOptions.overrideConfigFile,
+      extensions: config.eslintOptions.extensions ?? configDefaults.eslintOptions.extensions,
+      rulePaths: config.eslintOptions.rulePaths ?? configDefaults.eslintOptions.rulePaths,
+      ignorePath: config.eslintOptions.ignorePath ?? configDefaults.eslintOptions.ignorePath,
+      cache: config.eslintOptions.cache ?? configDefaults.eslintOptions.cache,
+      cacheLocation: config.eslintOptions.cacheLocation ?? configDefaults.eslintOptions.cacheLocation,
+      overrideConfig: config.eslintOptions.overrideConfig ?? configDefaults.eslintOptions.overrideConfig,
       cwd: this.cwd,
       resolvePluginsRelativeTo:
-        config.eslintOptions?.resolvePluginsRelativeTo ?? configDefaults.eslintOptions.resolvePluginsRelativeTo,
+        config.eslintOptions.resolvePluginsRelativeTo ?? configDefaults.eslintOptions.resolvePluginsRelativeTo,
     };
     const { type, ...eslintOptions } = this.eslintOptions;
     this.eslint = new ESLint(eslintOptions);

--- a/src/core.ts
+++ b/src/core.ts
@@ -1,8 +1,8 @@
-import { join, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { ESLint } from 'eslint';
 import isInstalledGlobally from 'is-installed-globally';
 import { DescriptionPosition } from './cli/prompt.js';
+import { Config, ESLintOptions, configDefaults } from './config.js';
 import { format } from './formatter/index.js';
 import {
   eslintInteractivePlugin,
@@ -13,9 +13,7 @@ import {
   OVERLAPPED_PROBLEM_MESSAGE,
 } from './plugin/index.js';
 import { unique } from './util/array.js';
-import { getCacheDir } from './util/cache.js';
 import { filterResultsByRuleId } from './util/eslint.js';
-import { DeepPartial } from './util/type-check.js';
 
 const MAX_AUTOFIX_PASSES = 10;
 
@@ -47,49 +45,6 @@ async function getUsedRuleIds(eslint: ESLint, targetFilePaths: string[]): Promis
 }
 
 export type Undo = () => Promise<void>;
-
-export type ESLintrcESLintOptions = { type: 'eslintrc' } & Pick<
-  ESLint.Options,
-  | 'useEslintrc'
-  | 'overrideConfigFile'
-  | 'extensions'
-  | 'rulePaths'
-  | 'ignorePath'
-  | 'cache'
-  | 'cacheLocation'
-  | 'overrideConfig'
-  | 'cwd'
-  | 'resolvePluginsRelativeTo'
->;
-
-export type ESLintOptions = ESLintrcESLintOptions; // TODO: support flat config
-
-/** The config of eslint-interactive */
-export type Config = {
-  patterns: string[];
-  formatterName?: string | undefined;
-  quiet?: boolean | undefined;
-  cwd?: string | undefined;
-  eslintOptions: ESLintOptions;
-};
-
-/** Default config of `Core` */
-export const configDefaults = {
-  formatterName: 'codeframe',
-  quiet: false,
-  cwd: process.cwd(),
-  eslintOptions: {
-    useEslintrc: true,
-    overrideConfigFile: undefined,
-    extensions: undefined,
-    rulePaths: undefined,
-    ignorePath: undefined,
-    cache: true,
-    cacheLocation: relative(process.cwd(), join(getCacheDir(), '.eslintcache')),
-    overrideConfig: undefined,
-    resolvePluginsRelativeTo: undefined,
-  },
-} satisfies DeepPartial<Config>;
 
 /**
  * The core of eslint-interactive.

--- a/src/core.ts
+++ b/src/core.ts
@@ -69,6 +69,7 @@ export type Config = {
   patterns: string[];
   formatterName?: string | undefined;
   quiet?: boolean | undefined;
+  cwd?: string | undefined;
   eslintOptions: ESLintOptions;
 };
 
@@ -76,6 +77,7 @@ export type Config = {
 export const configDefaults = {
   formatterName: 'codeframe',
   quiet: false,
+  cwd: process.cwd(),
   eslintOptions: {
     useEslintrc: true,
     overrideConfigFile: undefined,
@@ -85,7 +87,6 @@ export const configDefaults = {
     cache: true,
     cacheLocation: relative(process.cwd(), join(getCacheDir(), '.eslintcache')),
     overrideConfig: undefined,
-    cwd: process.cwd(),
     resolvePluginsRelativeTo: undefined,
   },
 } satisfies DeepPartial<Config>;
@@ -98,6 +99,7 @@ export class Core {
   readonly patterns: string[];
   readonly formatterName: string;
   readonly quiet: boolean;
+  readonly cwd: string;
   readonly eslintOptions: ESLintOptions;
   readonly eslint: ESLint;
 
@@ -105,6 +107,7 @@ export class Core {
     this.patterns = config.patterns;
     this.formatterName = config.formatterName ?? configDefaults.formatterName;
     this.quiet = config.quiet ?? configDefaults.quiet;
+    this.cwd = config.cwd ?? configDefaults.cwd;
     this.eslintOptions = {
       type: 'eslintrc',
       useEslintrc: config.eslintOptions?.useEslintrc ?? configDefaults.eslintOptions.useEslintrc,
@@ -115,7 +118,7 @@ export class Core {
       cache: config.eslintOptions?.cache ?? configDefaults.eslintOptions.cache,
       cacheLocation: config.eslintOptions?.cacheLocation ?? configDefaults.eslintOptions.cacheLocation,
       overrideConfig: config.eslintOptions?.overrideConfig ?? configDefaults.eslintOptions.overrideConfig,
-      cwd: config.eslintOptions?.cwd ?? configDefaults.eslintOptions.cwd,
+      cwd: this.cwd,
       resolvePluginsRelativeTo:
         config.eslintOptions?.resolvePluginsRelativeTo ?? configDefaults.eslintOptions.resolvePluginsRelativeTo,
     };
@@ -142,7 +145,7 @@ export class Core {
     // Therefore, the function may not exist in versions lower than 7.29.0.
     const rulesMeta: ESLint.LintResultData['rulesMeta'] = this.eslint.getRulesMetaForResults?.(results) ?? {};
 
-    return format(results, { rulesMeta, cwd: this.eslintOptions?.cwd ?? configDefaults.eslintOptions.cwd });
+    return format(results, { rulesMeta, cwd: this.cwd });
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export { run, type Options } from './cli/run.js';
-export { Core, type Config, type ESLintOptions, configDefaults } from './core.js';
+export { Core } from './core.js';
+export { type Config, type ESLintOptions, configDefaults } from './config.js';
 export { takeRuleStatistics, type RuleStatistic } from './formatter/index.js';
 export { type FixableMaker, type SuggestionFilter, type FixContext } from './plugin/index.js';

--- a/src/util/type-check.ts
+++ b/src/util/type-check.ts
@@ -6,3 +6,7 @@ export function unreachable(message?: string): never {
 export function notEmpty<TValue>(value: TValue | null | undefined): value is TValue {
   return value !== null && value !== undefined;
 }
+
+export type DeepPartial<T> = {
+  [P in keyof T]?: T[P] extends Record<string, unknown> ? DeepPartial<T[P]> : T[P];
+};


### PR DESCRIPTION
This change is a third step towards resolving https://github.com/mizdra/eslint-interactive/issues/283.

## Breaking changes
- Replace the `cwd` option of `Core` with the `eslintOptions.cwd` option
- `Core` requires the `eslintOptions.type` option