### PR TITLE
Drop ESLint v7

### DIFF
--- a/.github/workflows/ci-node.yml
+++ b/.github/workflows/ci-node.yml
@@ -27,7 +27,7 @@ jobs:
       fail-fast: false
       matrix:
         node: [18, 20]
-        eslint: ['^7.0.0', '^8.0.0']
+        eslint: ['^8.0.0']
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
@@ -49,7 +49,7 @@ jobs:
       fail-fast: false
       matrix:
         node: [18, 20]
-        eslint: ['^7.0.0', '^8.0.0']
+        eslint: ['^8.0.0']
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "yargs": "^17.7.2"
   },
   "peerDependencies": {
-    "eslint": "^7.0.0 || ^8.0.0"
+    "eslint": ">=8.0.0"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/src/core.test.ts
+++ b/src/core.test.ts
@@ -8,8 +8,6 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { Core } from './core.js';
 import { createIFF } from './test-util/fixtures.js';
 
-const testIf = (condition: boolean) => (condition ? test : test.skip);
-
 const rootDir = join(dirname(fileURLToPath(import.meta.url)), '..');
 
 // Normalize `message` for the snapshot.
@@ -181,8 +179,7 @@ describe('Core', () => {
       expect(countWarnings(resultsWithQuiet)).toEqual(0);
     });
   });
-  // This test fails because the documentation url format is not supported in eslint 7.x.x and 8.0.0. Therefore, ignore this test.
-  testIf(!ESLint.version.startsWith('7.'))('printSummaryOfResults', async () => {
+  test('printSummaryOfResults', async () => {
     const results = await core.lint();
     vi.spyOn(ESLint.prototype, 'getRulesMetaForResults').mockImplementationOnce(() => {
       return {

--- a/src/core.ts
+++ b/src/core.ts
@@ -62,10 +62,7 @@ export class Core {
    * @param results The lint results of the project to print summary
    */
   formatResultSummary(results: ESLint.LintResult[]): string {
-    // NOTE: `getRulesMetaForResults` is a feature added in ESLint 7.29.0.
-    // Therefore, the function may not exist in versions lower than 7.29.0.
-    const rulesMeta: ESLint.LintResultData['rulesMeta'] = this.eslint.getRulesMetaForResults?.(results) ?? {};
-
+    const rulesMeta = this.eslint.getRulesMetaForResults(results);
     return format(results, { rulesMeta, cwd: this.config.cwd });
   }
 


### PR DESCRIPTION
This change is a sixth step towards resolving https://github.com/mizdra/eslint-interactive/issues/283.