### PR TITLE
Require ESLint v8.45.0+

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ It also supports the following actions in addition to `eslint --fix`. All action
 - Apply suggestions
 - Make forcibly fixable and run `eslint --fix`
 
+## Requirements
+
+- Node.js `>=18.0.0`
+- ESLint `>=8.45.0`
+  - If you use ESLint `<8.45.0`, use `eslint-interactive@^10`.
+
 ## Installation
 
 :memo: NOTE: The globally installed `eslint-interactive` is **not officially supported**. It is recommended to install `eslint-interactive` locally. See [FAQ](#why-is-global-installation-not-officially-supported).

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "yargs": "^17.7.2"
   },
   "peerDependencies": {
-    "eslint": ">=8.0.0"
+    "eslint": ">=8.45.0"
   },
   "engines": {
     "node": ">=18.0.0"


### PR DESCRIPTION
follow-up: #339 

This change is a 7th step towards resolving https://github.com/mizdra/eslint-interactive/issues/283.

To support flat config, require the version that exports `FlatESLint` and `LegacyESLint` from `eslint/use-at-your-own-risk` package.

- https://github.com/eslint/eslint/blob/v8.45.0/lib/unsupported-api.js