### PR TITLE
Fix peer deps range

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "yargs": "^17.7.2"
   },
   "peerDependencies": {
-    "eslint": ">=8.45.0, 9.0.0-alpha.0"
+    "eslint": "^8.45.0 || ^9.0.0"
   },
   "engines": {
     "node": ">=18.0.0"


### PR DESCRIPTION
There was an error in the notation of the version range for peerDeps. As a result, versions that should have been allowed were not allowed.

```console
$ npm i -D eslint-interactive
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR!
npm ERR! While resolving: undefined@undefined
npm ERR! Found: eslint@8.57.0
npm ERR! node_modules/eslint
npm ERR!   dev eslint@"^8.57.0" from the root project
npm ERR!
npm ERR! Could not resolve dependency:
npm ERR! peer eslint@">=8.45.0, 9.0.0-alpha.0" from eslint-interactive@11.0.1
npm ERR! node_modules/eslint-interactive
npm ERR!   dev eslint-interactive@"*" from the root project
npm ERR!
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
npm ERR!
npm ERR!
npm ERR! For a full report see:
npm ERR! /Users/mizdra/.npm/_logs/2024-05-11T15_01_04_642Z-eresolve-report.txt

npm ERR! A complete log of this run can be found in: /Users/mizdra/.npm/_logs/2024-05-11T15_01_04_642Z-debug-0.log
```