### PR TITLE
Remove source map in production as it does not make debugging easier

### DIFF
--- a/bin/eslint-interactive.js
+++ b/bin/eslint-interactive.js
@@ -12,12 +12,6 @@ const scriptFile = resolve(dir, '_eslint-interactive.js');
 
 spawnSync(
   'node',
-  [
-    '--enable-source-maps',
-    '--unhandled-rejections=strict',
-    '--experimental-import-meta-resolve',
-    scriptFile,
-    ...process.argv.slice(2),
-  ],
+  ['--unhandled-rejections=strict', '--experimental-import-meta-resolve', scriptFile, ...process.argv.slice(2)],
   { stdio: 'inherit' },
 );


### PR DESCRIPTION
The source map is useful when developing eslint-interactive. However, it is not useful in production.