### PR TITLE
Use `stylish` as default formatter instead of eslint-formatter-codeframe

### DIFF
--- a/bin/eslint-interactive.js
+++ b/bin/eslint-interactive.js
@@ -10,8 +10,4 @@ const dir = join(dirname(fileURLToPath(import.meta.url)));
 
 const scriptFile = resolve(dir, '_eslint-interactive.js');
 
-spawnSync(
-  'node',
-  ['--unhandled-rejections=strict', '--experimental-import-meta-resolve', scriptFile, ...process.argv.slice(2)],
-  { stdio: 'inherit' },
-);
+spawnSync('node', ['--unhandled-rejections=strict', scriptFile, ...process.argv.slice(2)], { stdio: 'inherit' });

--- a/e2e-test/global-installation/index.test.ts
+++ b/e2e-test/global-installation/index.test.ts
@@ -26,7 +26,7 @@ test('verify installation', async () => {
   expect(result.toString().trim()).toBe(VERSION);
 });
 
-test('can print error with eslint-formatter-codeframe', async () => {
+test('can print error with stylish', async () => {
   const child = spawn(
     'eslint-interactive',
     [
@@ -46,6 +46,6 @@ test('can print error with eslint-formatter-codeframe', async () => {
   await streamWatcher.match(/In what way are the details displayed\?/);
   child.stdin.write('0'); // Focus on `Print in terminal`
   child.stdin.write(LF); // Confirm the choice
-  await streamWatcher.match(/Missing semicolon/); // formatted by eslint-formatter-codeframe
+  await streamWatcher.match(/Missing semicolon/);
   child.stdin.write(ETX); // Exit
 });

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "chalk": "^5.3.0",
     "comlink": "^4.4.1",
     "enquirer": "^2.4.1",
-    "eslint-formatter-codeframe": "^7.32.1",
     "estraverse": "^5.3.0",
     "find-cache-dir": "^5.0.0",
     "is-installed-globally": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "@types/yargs": "^17.0.29",
     "dedent": "^1.5.1",
     "eslint": "^8.57.0",
-    "import-meta-resolve": "^4.0.0",
     "npm-run-all2": "^5.0.0",
     "prettier": "3.0.3",
     "stream-match": "^4.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,9 +78,6 @@ importers:
       eslint:
         specifier: ^8.57.0
         version: 8.57.0
-      import-meta-resolve:
-        specifier: ^4.0.0
-        version: 4.0.0
       npm-run-all2:
         specifier: ^5.0.0
         version: 5.0.2
@@ -1982,10 +1979,6 @@ packages:
     dependencies:
       parent-module: 1.0.1
       resolve-from: 4.0.0
-    dev: true
-
-  /import-meta-resolve@4.0.0:
-    resolution: {integrity: sha512-okYUR7ZQPH+efeuMJGlq4f8ubUgO50kByRPyt/Cy1Io4PSRsPjxME+YlVaCOx+NIToW7hCsZNFJyTPFFKepRSA==}
     dev: true
 
   /imurmurhash@0.1.4:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,9 +20,6 @@ importers:
       enquirer:
         specifier: ^2.4.1
         version: 2.4.1
-      eslint-formatter-codeframe:
-        specifier: ^7.32.1
-        version: 7.32.1
       estraverse:
         specifier: ^5.3.0
         version: 5.3.0
@@ -113,12 +110,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /@babel/code-frame@7.12.11:
-    resolution: {integrity: sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==}
-    dependencies:
-      '@babel/highlight': 7.18.6
-    dev: false
-
   /@babel/code-frame@7.22.13:
     resolution: {integrity: sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==}
     engines: {node: '>=6.9.0'}
@@ -130,15 +121,7 @@ packages:
   /@babel/helper-validator-identifier@7.22.20:
     resolution: {integrity: sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==}
     engines: {node: '>=6.9.0'}
-
-  /@babel/highlight@7.18.6:
-    resolution: {integrity: sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/helper-validator-identifier': 7.22.20
-      chalk: 2.4.2
-      js-tokens: 4.0.0
-    dev: false
+    dev: true
 
   /@babel/highlight@7.22.20:
     resolution: {integrity: sha512-dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==}
@@ -897,6 +880,7 @@ packages:
     engines: {node: '>=4'}
     dependencies:
       color-convert: 1.9.3
+    dev: true
 
   /ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
@@ -1078,6 +1062,7 @@ packages:
       ansi-styles: 3.2.1
       escape-string-regexp: 1.0.5
       supports-color: 5.5.0
+    dev: true
 
   /chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -1085,6 +1070,7 @@ packages:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
+    dev: true
 
   /chalk@5.3.0:
     resolution: {integrity: sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==}
@@ -1138,6 +1124,7 @@ packages:
     resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
     dependencies:
       color-name: 1.1.3
+    dev: true
 
   /color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -1147,6 +1134,7 @@ packages:
 
   /color-name@1.1.3:
     resolution: {integrity: sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==}
+    dev: true
 
   /color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
@@ -1386,6 +1374,7 @@ packages:
   /escape-string-regexp@1.0.5:
     resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
     engines: {node: '>=0.8.0'}
+    dev: true
 
   /escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
@@ -1400,14 +1389,6 @@ packages:
     dependencies:
       eslint: 8.57.0
     dev: true
-
-  /eslint-formatter-codeframe@7.32.1:
-    resolution: {integrity: sha512-DK/3Q3+zVKq/7PdSYiCxPrsDF8H/TRMK5n8Hziwr4IMkMy+XiKSwbpj25AdajS63I/B61Snetq4uVvX9fOLyAg==}
-    engines: {node: ^10.12.0 || >=12.0.0}
-    dependencies:
-      '@babel/code-frame': 7.12.11
-      chalk: 4.1.2
-    dev: false
 
   /eslint-import-resolver-node@0.3.9:
     resolution: {integrity: sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==}
@@ -1934,6 +1915,7 @@ packages:
   /has-flag@3.0.0:
     resolution: {integrity: sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==}
     engines: {node: '>=4'}
+    dev: true
 
   /has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
@@ -2212,6 +2194,7 @@ packages:
 
   /js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+    dev: true
 
   /js-yaml@4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
@@ -3055,6 +3038,7 @@ packages:
     engines: {node: '>=4'}
     dependencies:
       has-flag: 3.0.0
+    dev: true
 
   /supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -697,7 +697,7 @@ packages:
     dependencies:
       '@typescript-eslint/typescript-estree': 5.59.2(typescript@5.6.2)
       '@typescript-eslint/utils': 5.59.2(eslint@8.57.0)(typescript@5.6.2)
-      debug: 4.3.4
+      debug: 4.3.7
       eslint: 8.57.0
       tsutils: 3.21.0(typescript@5.6.2)
       typescript: 5.6.2
@@ -721,7 +721,7 @@ packages:
     dependencies:
       '@typescript-eslint/types': 5.59.2
       '@typescript-eslint/visitor-keys': 5.59.2
-      debug: 4.3.4
+      debug: 4.3.7
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.4

--- a/src/__snapshots__/core.test.ts.snap
+++ b/src/__snapshots__/core.test.ts.snap
@@ -271,18 +271,15 @@ exports[`Core > lint > returns lint results 1`] = `
 exports[`Core > makeFixableAndFix 1`] = `"const _a = 1;"`;
 
 exports[`Core > printDetailsOfResults 1`] = `
-"[31merror[39m: [1mBan exponentiation operator[22m [2m(ban-exponentiation-operator)[22m at [32m<fixture>/src/ban-exponentiation-operator.js:1:1[39m:
-> 1 | 2 ** 2;
-    | ^
-
-
-[31merror[39m: [1mDefinition for rule 'import/order' was not found[22m [2m(import/order)[22m at [32m<fixture>/src/import-order.js:1:1[39m:
-> 1 | import b from 'b';
-    | ^
-  2 | import a from 'a';
-
-
-[31m[1m2 errors found.[22m[39m"
+"[0m[0m
+[0m[4m<fixture>/src/ban-exponentiation-operator.js[24m[0m
+[0m  [2m1:1[22m  [31merror[39m  Ban exponentiation operator  [2mban-exponentiation-operator[22m[0m
+[0m[0m
+[0m[4m<fixture>/src/import-order.js[24m[0m
+[0m  [2m1:1[22m  [31merror[39m  Definition for rule 'import/order' was not found  [2mimport/order[22m[0m
+[0m[0m
+[0m[31m[1m✖ 2 problems (2 errors, 0 warnings)[22m[39m[0m
+[0m[31m[1m[22m[39m[0m"
 `;
 
 exports[`Core > printSummaryOfResults 1`] = `

--- a/src/cli/parse-argv.ts
+++ b/src/cli/parse-argv.ts
@@ -20,7 +20,7 @@ export type ParsedCLIOptions = {
 
 /** Default CLI Options */
 export const cliOptionsDefaults = {
-  formatterName: 'codeframe',
+  formatterName: 'stylish',
   quiet: false,
   useEslintrc: true,
   cache: true,

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -44,7 +44,7 @@ export async function run(options: Options) {
       // ref: https://github.com/chalk/supports-color/issues/97, https://github.com/nodejs/node/issues/26946
       FORCE_HYPERLINK: terminalLink.isSupported ? '1' : '0',
     },
-    // NOTE: Pass CLI options (--experimental-import-meta-resolve, etc.) to the worker
+    // NOTE: Pass CLI options (--unhandled-rejections=strict, etc.) to the worker
     execArgv: process.execArgv,
   });
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/core.test.ts
+++ b/src/core.test.ts
@@ -3,7 +3,6 @@ import { dirname, join, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import dedent from 'dedent';
 import { ESLint, Linter } from 'eslint';
-import { resolve } from 'import-meta-resolve';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { Core } from './core.js';
 import { LegacyESLint } from './eslint/use-at-your-own-risk.js';
@@ -149,9 +148,7 @@ const iff = await createIFF({
 
 const core = new Core({
   patterns: ['src'],
-  // For some reason, the test fails if `formatterName === 'codeframe'`.
-  // So here we overwrite it.
-  formatterName: fileURLToPath(resolve('eslint-formatter-codeframe', import.meta.url)),
+  formatterName: 'stylish',
   cwd: iff.rootDir,
   eslintOptions: { type: 'eslintrc', rulePaths: ['rules'] },
 });

--- a/src/core.ts
+++ b/src/core.ts
@@ -1,7 +1,5 @@
 import { writeFile } from 'node:fs/promises';
-import { fileURLToPath } from 'node:url';
 import { ESLint, Rule } from 'eslint';
-import isInstalledGlobally from 'is-installed-globally';
 import { DescriptionPosition } from './cli/prompt.js';
 import { Config, NormalizedConfig, normalizeConfig } from './config.js';
 import { LegacyESLint, FlatESLint } from './eslint/use-at-your-own-risk.js';
@@ -112,15 +110,7 @@ export class Core {
    */
   async formatResultDetails(results: ESLint.LintResult[], ruleIds: (string | null)[]): Promise<string> {
     const formatterName = this.config.formatterName;
-
-    // When eslint-interactive is installed globally, eslint-formatter-codeframe will also be installed globally.
-    // On the other hand, `eslint.loadFormatter` cannot load the globally installed formatter by name. So here it loads them by path.
-    const resolvedFormatterNameOrPath =
-      isInstalledGlobally && formatterName === 'codeframe'
-        ? fileURLToPath(import.meta.resolve('eslint-formatter-codeframe', import.meta.resolve('eslint-interactive')))
-        : formatterName;
-
-    const formatter = await this.eslint.loadFormatter(resolvedFormatterNameOrPath);
+    const formatter = await this.eslint.loadFormatter(formatterName);
     return formatter.format(filterResultsByRuleId(results, ruleIds));
   }
 

--- a/vite.config.base.ts
+++ b/vite.config.base.ts
@@ -12,7 +12,6 @@ export const baseConfig = defineConfig({
     env: {
       FORCE_HYPERLINK: '1',
       FORCE_COLOR: '1',
-      NODE_OPTIONS: '--experimental-import-meta-resolve',
     },
     exclude: [...configDefaults.exclude, 'tmp/**'],
   },


### PR DESCRIPTION
close: #373 

- I think it depends on the situation as to whether `codeframe` or `stylish` is better.
  - `codeframe` is excellent for displaying the details of a problem. However, the output is too large, so it is not easy to see at a glance.
  - `stylish` has a small output, so it is easy to see at a glance. However, it is not possible to display problem details.
- I was wondering which one to make the default, but I decided to make `stylish` the default for the following reasons.
  - `codeframe` is a 3rd-party package, and it is a little difficult to bundle it with `eslint-interactive`.
  - `codeframe` makes the package size of Peslint-interactive` larger.
  - If necessary, users can install `eslint-formatter-codeframe` themselves and use it as the formatter for `eslint-interactive`.

## Screenshots

Before:
![ 2024-09-28 18 19 55](https://github.com/user-attachments/assets/24fbdd77-770b-4948-95f3-a62bca1b72f9)

After:
![ 2024-09-28 18 18 58](https://github.com/user-attachments/assets/9d95a848-5f13-4700-b73d-a10a4d956894)
