### PR TITLE
Use `util.parseArgs` instead of `yargs`

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@tsconfig/strictest": "^2.0.5",
     "@types/estraverse": "^5.1.7",
     "@types/estree": "^1.0.6",
-    "@types/node": "^22.7.4",
+    "@types/node": "^22.14.1",
     "@types/yargs": "^17.0.33",
     "dedent": "^1.5.3",
     "eslint": "^9.25.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "@types/estraverse": "^5.1.7",
     "@types/estree": "^1.0.6",
     "@types/node": "^22.14.1",
-    "@types/yargs": "^17.0.33",
     "dedent": "^1.5.3",
     "eslint": "^9.25.1",
     "eslint-plugin-import": "^2.31.0",
@@ -60,8 +59,7 @@
     "is-installed-globally": "^1.0.0",
     "ora": "^8.1.0",
     "table": "^6.8.2",
-    "terminal-link": "^3.0.0",
-    "yargs": "^17.7.2"
+    "terminal-link": "^3.0.0"
   },
   "peerDependencies": {
     "eslint": "^8.45.0 || ^9.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,9 +38,6 @@ importers:
       terminal-link:
         specifier: ^3.0.0
         version: 3.0.0
-      yargs:
-        specifier: ^17.7.2
-        version: 17.7.2
     devDependencies:
       '@mizdra/eslint-config-mizdra':
         specifier: ^6.1.0
@@ -66,9 +63,6 @@ importers:
       '@types/node':
         specifier: ^22.14.1
         version: 22.14.1
-      '@types/yargs':
-        specifier: ^17.0.33
-        version: 17.0.33
       dedent:
         specifier: ^1.5.3
         version: 1.5.3
@@ -623,16 +617,6 @@ packages:
       undici-types: 6.21.0
     dev: true
 
-  /@types/yargs-parser@21.0.3:
-    resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
-    dev: true
-
-  /@types/yargs@17.0.33:
-    resolution: {integrity: sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==}
-    dependencies:
-      '@types/yargs-parser': 21.0.3
-    dev: true
-
   /@typescript-eslint/eslint-plugin@8.31.0(@typescript-eslint/parser@8.31.0)(eslint@9.25.1)(typescript@5.6.2):
     resolution: {integrity: sha512-evaQJZ/J/S4wisevDvC1KFZkPzRetH8kYZbkgcTRyql3mcKsf+ZFDV1BVWUGTCAW5pQHoqn5gK5b8kn7ou9aFQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -1148,15 +1132,6 @@ packages:
     engines: {node: '>=6'}
     dev: false
 
-  /cliui@8.0.1:
-    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
-    engines: {node: '>=12'}
-    dependencies:
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-      wrap-ansi: 7.0.0
-    dev: false
-
   /color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -1539,11 +1514,6 @@ packages:
       '@esbuild/win32-ia32': 0.19.9
       '@esbuild/win32-x64': 0.19.9
     dev: true
-
-  /escalade@3.1.1:
-    resolution: {integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==}
-    engines: {node: '>=6'}
-    dev: false
 
   /escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
@@ -1955,11 +1925,6 @@ packages:
   /functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
     dev: true
-
-  /get-caller-file@2.0.5:
-    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
-    engines: {node: 6.* || 8.* || >= 10.*}
-    dev: false
 
   /get-east-asian-width@1.2.0:
     resolution: {integrity: sha512-2nk+7SIVb14QrgXFHcm84tD4bKQz0RxPuMT8Ag5KPOq7J5fEmAg0UbXdTOSHqNuHSU28k55qnceesxXRZGzKWA==}
@@ -3026,11 +2991,6 @@ packages:
       set-function-name: 2.0.2
     dev: true
 
-  /require-directory@2.1.1:
-    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
-    engines: {node: '>=0.10.0'}
-    dev: false
-
   /require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
@@ -3836,15 +3796,6 @@ packages:
       string-width: 7.2.0
     dev: false
 
-  /wrap-ansi@7.0.0:
-    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
-    engines: {node: '>=10'}
-    dependencies:
-      ansi-styles: 4.3.0
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-    dev: false
-
   /wrap-ansi@9.0.0:
     resolution: {integrity: sha512-G8ura3S+3Z2G+mkgNRq8dqaFZAuxfsxpBB8OCTGRTCtp+l/v9nbFNmCUP1BZMts3G1142MsZfn6eeUKrr4PD1Q==}
     engines: {node: '>=18'}
@@ -3852,29 +3803,6 @@ packages:
       ansi-styles: 6.2.1
       string-width: 7.2.0
       strip-ansi: 7.1.0
-    dev: false
-
-  /y18n@5.0.8:
-    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
-    engines: {node: '>=10'}
-    dev: false
-
-  /yargs-parser@21.1.1:
-    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
-    engines: {node: '>=12'}
-    dev: false
-
-  /yargs@17.7.2:
-    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
-    engines: {node: '>=12'}
-    dependencies:
-      cliui: 8.0.1
-      escalade: 3.1.1
-      get-caller-file: 2.0.5
-      require-directory: 2.1.1
-      string-width: 4.2.3
-      y18n: 5.0.8
-      yargs-parser: 21.1.1
     dev: false
 
   /yocto-queue@0.1.0:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,8 +64,8 @@ importers:
         specifier: ^1.0.6
         version: 1.0.6
       '@types/node':
-        specifier: ^22.7.4
-        version: 22.7.4
+        specifier: ^22.14.1
+        version: 22.14.1
       '@types/yargs':
         specifier: ^17.0.33
         version: 17.0.33
@@ -92,7 +92,7 @@ importers:
         version: 5.6.2
       vitest:
         specifier: ^2.1.1
-        version: 2.1.1(@types/node@22.7.4)
+        version: 2.1.1(@types/node@22.14.1)
 
   e2e-test/import-as-esm-from-esm:
     dependencies:
@@ -617,10 +617,10 @@ packages:
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
     dev: true
 
-  /@types/node@22.7.4:
-    resolution: {integrity: sha512-y+NPi1rFzDs1NdQHHToqeiX2TIS79SWEAw9GYhkkx8bD0ChpfqC+n2j5OXOCpzfojBEBt6DnEnnG9MY0zk1XLg==}
+  /@types/node@22.14.1:
+    resolution: {integrity: sha512-u0HuPQwe/dHrItgHHpmw3N2fYCR6x4ivMNbPHRkBVP4CvN+kiRrKHWk3i8tXiO/joPwXLMYvF9TTF0eqgHIuOw==}
     dependencies:
-      undici-types: 6.19.8
+      undici-types: 6.21.0
     dev: true
 
   /@types/yargs-parser@21.0.3:
@@ -773,7 +773,7 @@ packages:
       '@vitest/spy': 2.1.1
       estree-walker: 3.0.3
       magic-string: 0.30.11
-      vite: 5.0.10(@types/node@22.7.4)
+      vite: 5.0.10(@types/node@22.14.1)
     dev: true
 
   /@vitest/pretty-format@2.1.1:
@@ -3615,8 +3615,8 @@ packages:
       which-boxed-primitive: 1.1.1
     dev: true
 
-  /undici-types@6.19.8:
-    resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
+  /undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
     dev: true
 
   /uri-js@4.4.1:
@@ -3625,7 +3625,7 @@ packages:
       punycode: 2.3.1
     dev: true
 
-  /vite-node@2.1.1(@types/node@22.7.4):
+  /vite-node@2.1.1(@types/node@22.14.1):
     resolution: {integrity: sha512-N/mGckI1suG/5wQI35XeR9rsMsPqKXzq1CdUndzVstBj/HvyxxGctwnK6WX43NGt5L3Z5tcRf83g4TITKJhPrA==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
@@ -3633,7 +3633,7 @@ packages:
       cac: 6.7.14
       debug: 4.3.7
       pathe: 1.1.2
-      vite: 5.0.10(@types/node@22.7.4)
+      vite: 5.0.10(@types/node@22.14.1)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -3645,7 +3645,7 @@ packages:
       - terser
     dev: true
 
-  /vite@5.0.10(@types/node@22.7.4):
+  /vite@5.0.10(@types/node@22.14.1):
     resolution: {integrity: sha512-2P8J7WWgmc355HUMlFrwofacvr98DAjoE52BfdbwQtyLH06XKwaL/FMnmKM2crF0iX4MpmMKoDlNCB1ok7zHCw==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
@@ -3673,7 +3673,7 @@ packages:
       terser:
         optional: true
     dependencies:
-      '@types/node': 22.7.4
+      '@types/node': 22.14.1
       esbuild: 0.19.9
       postcss: 8.4.32
       rollup: 4.9.1
@@ -3681,7 +3681,7 @@ packages:
       fsevents: 2.3.3
     dev: true
 
-  /vitest@2.1.1(@types/node@22.7.4):
+  /vitest@2.1.1(@types/node@22.14.1):
     resolution: {integrity: sha512-97We7/VC0e9X5zBVkvt7SGQMGrRtn3KtySFQG5fpaMlS+l62eeXRQO633AYhSTC3z7IMebnPPNjGXVGNRFlxBA==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
@@ -3706,7 +3706,7 @@ packages:
       jsdom:
         optional: true
     dependencies:
-      '@types/node': 22.7.4
+      '@types/node': 22.14.1
       '@vitest/expect': 2.1.1
       '@vitest/mocker': 2.1.1(@vitest/spy@2.1.1)(vite@5.0.10)
       '@vitest/pretty-format': 2.1.1
@@ -3723,8 +3723,8 @@ packages:
       tinyexec: 0.3.0
       tinypool: 1.0.1
       tinyrainbow: 1.2.0
-      vite: 5.0.10(@types/node@22.7.4)
-      vite-node: 2.1.1(@types/node@22.7.4)
+      vite: 5.0.10(@types/node@22.14.1)
+      vite-node: 2.1.1(@types/node@22.14.1)
       why-is-node-running: 2.3.0
     transitivePeerDependencies:
       - less

--- a/src/cli/parse-argv.test.ts
+++ b/src/cli/parse-argv.test.ts
@@ -17,6 +17,9 @@ describe('parseArgv', () => {
     expect(parseArgv([...baseArgs, '--config', 'override-config-file.json']).overrideConfigFile).toStrictEqual(
       'override-config-file.json',
     );
+    expect(parseArgv([...baseArgs, '-c', 'override-config-file.json']).overrideConfigFile).toStrictEqual(
+      'override-config-file.json',
+    );
   });
   test('--rulesdir', () => {
     expect(parseArgv([...baseArgs, '--rulesdir', 'foo']).rulePaths).toStrictEqual(['foo']);

--- a/src/cli/parse-argv.test.ts
+++ b/src/cli/parse-argv.test.ts
@@ -11,7 +11,6 @@ describe('parseArgv', () => {
   });
   test('--no-eslintrc', () => {
     expect(parseArgv([...baseArgs, '--no-eslintrc']).useEslintrc).toStrictEqual(false);
-    expect(parseArgv([...baseArgs, '--no-eslintrc=false']).useEslintrc).toStrictEqual(true);
   });
   test('--config', () => {
     expect(parseArgv([...baseArgs]).overrideConfigFile).toStrictEqual(undefined);
@@ -47,7 +46,6 @@ describe('parseArgv', () => {
   test('--cache', () => {
     expect(parseArgv([...baseArgs, '--cache']).cache).toBe(true);
     expect(parseArgv([...baseArgs, '--no-cache']).cache).toBe(false);
-    expect(parseArgv([...baseArgs, '--cache', 'false']).cache).toBe(false);
   });
   test('--cache-location', () => {
     expect(parseArgv([...baseArgs, '--cache-location', '.eslintcache']).cacheLocation).toBe('.eslintcache');

--- a/src/cli/parse-argv.ts
+++ b/src/cli/parse-argv.ts
@@ -1,5 +1,5 @@
 import { join, relative } from 'node:path';
-import yargs from 'yargs';
+import { parseArgs } from 'node:util';
 import { getCacheDir } from '../util/cache.js';
 import type { DeepPartial } from '../util/type-check.js';
 import { VERSION } from './package.js';
@@ -29,90 +29,81 @@ export const cliOptionsDefaults = {
 
 /** Parse CLI options */
 export function parseArgv(argv: string[]): ParsedCLIOptions {
-  const parsedArgv = yargs(argv.slice(2))
-    .wrap(Math.min(140, process.stdout.columns))
-    .scriptName('eslint-interactive')
-    .version(VERSION)
-    .usage('$0 [file.js] [dir]')
-    .detectLocale(false)
-    // NOTE: yargs doesn't support negative only option. So we use `--eslintrc` instead of `--no-eslintrc`.
-    .option('eslintrc', {
-      type: 'boolean',
-      describe: 'Enable use of configuration from .eslintrc.*',
-      default: cliOptionsDefaults.useEslintrc,
-    })
-    .option('config', {
-      alias: 'c',
-      type: 'string',
-      describe: 'Use this configuration, overriding .eslintrc.* config options if present',
-    })
-    .option('ext', {
-      type: 'array',
-      describe: 'Specify JavaScript file extensions',
-    })
-    .nargs('ext', 1)
-    .option('resolve-plugins-relative-to', {
-      type: 'string',
-      describe: 'A folder where plugins should be resolved from, CWD by default',
-    })
-    .option('rulesdir', {
-      type: 'array',
-      describe: 'Use additional rules from this directory',
-    })
-    .nargs('rulesdir', 1)
-    // Following ESLint, --ignore-path accepts only one path. However, this limitation may be relaxed in the future.
-    // ref: https://github.com/eslint/eslint/issues/9794
-    .option('ignore-path', {
-      type: 'string',
-      describe: 'Specify path of ignore file',
-    })
-    .option('format', {
-      type: 'string',
-      describe: 'Specify the format to be used for the `Display problem messages` action',
-      default: cliOptionsDefaults.formatterName,
-    })
-    .option('quiet', {
-      type: 'boolean',
-      describe: 'Report errors only',
-      default: cliOptionsDefaults.quiet,
-    })
-    .option('cache', {
-      type: 'boolean',
-      describe: 'Only check changed files',
-      default: cliOptionsDefaults.cache,
-    })
-    .option('cache-location', {
-      type: 'string',
-      describe: `Path to the cache file or directory`,
-      default: cliOptionsDefaults.cacheLocation,
-    })
-    .example('$0 ./src', 'Lint ./src/ directory')
-    .example('$0 ./src ./test', 'Lint multiple directories')
-    .example("$0 './src/**/*.{ts,tsx,vue}'", 'Lint with glob pattern')
-    .example('$0 ./src --ext .ts,.tsx,.vue', 'Lint with custom extensions')
-    .example('$0 ./src --rulesdir ./rules', 'Lint with custom rules')
-    .example('$0 ./src --no-eslintrc --config ./.eslintrc.ci.js', 'Lint with custom config')
-    .parseSync();
-  // NOTE: convert `string` type because yargs convert `'10'` (`string` type) into `10` (`number` type)
-  // and `lintFiles` only accepts `string[]`.
-  const patterns = parsedArgv._.map((pattern) => pattern.toString());
-  const rulePaths = parsedArgv.rulesdir?.map((rulePath) => rulePath.toString());
-  const extensions = parsedArgv.ext
-    ?.map((extension) => extension.toString())
-    // map '.js,.ts' into ['.js', '.ts']
-    .flatMap((extension) => extension.split(','));
-  const formatterName = parsedArgv.format;
+  const options = {
+    'eslintrc': { type: 'boolean', default: cliOptionsDefaults.useEslintrc },
+    'config': { type: 'string', short: 'c' },
+    'ext': { type: 'string', multiple: true },
+    'resolve-plugins-relative-to': { type: 'string' },
+    'rulesdir': { type: 'string', multiple: true },
+    'ignore-path': { type: 'string' },
+    'format': { type: 'string', default: cliOptionsDefaults.formatterName },
+    'quiet': { type: 'boolean', default: cliOptionsDefaults.quiet },
+    'cache': { type: 'boolean', default: cliOptionsDefaults.cache },
+    'cache-location': { type: 'string', default: cliOptionsDefaults.cacheLocation },
+    'version': { type: 'boolean' },
+    'help': { type: 'boolean' },
+  } as const;
+
+  const { values, positionals } = parseArgs({
+    allowPositionals: true,
+    allowNegative: true,
+    strict: true,
+    args: argv.slice(2),
+    options,
+  });
+
+  if (values.version) {
+    console.log(VERSION);
+    // eslint-disable-next-line n/no-process-exit
+    process.exit(0);
+  }
+
+  if (values.help) {
+    console.log(`
+eslint-interactive [file.js] [dir]
+
+Options:
+      --help                         Show help                                                                                     [boolean]
+      --version                      Show version number                                                                           [boolean]
+      --eslintrc                     Enable use of configuration from .eslintrc.*                                  [boolean] [default: true]
+  -c, --config                       Use this configuration, overriding .eslintrc.* config options if present                       [string]
+      --resolve-plugins-relative-to  A folder where plugins should be resolved from, CWD by default                                 [string]
+      --ext                          Specify JavaScript file extensions                                                              [array]
+      --rulesdir                     Use additional rules from this directory                                                        [array]
+      --ignore-path                  Specify path of ignore file                                                                    [string]
+      --format                       Specify the format to be used for the \`Display problem messages\` action [string] [default: "codeframe"]
+      --quiet                        Report errors only                                                           [boolean] [default: false]
+      --cache                        Only check changed files                                                      [boolean] [default: true]
+      --cache-location               Path to the cache file or directory
+
+Examples:
+  eslint-interactive ./src                                           Lint ./src/ directory
+  eslint-interactive ./src ./test                                    Lint multiple directories
+  eslint-interactive './src/**/*.{ts,tsx,vue}'                       Lint with glob pattern
+  eslint-interactive ./src --ext .ts,.tsx,.vue                       Lint with custom extensions
+  eslint-interactive ./src --rulesdir ./rules                        Lint with custom rules
+  eslint-interactive ./src --no-eslintrc --config ./.eslintrc.ci.js  Lint with custom config
+      `);
+    // eslint-disable-next-line n/no-process-exit
+    process.exit(0);
+  }
+
+  const patterns = positionals.map((pattern) => pattern.toString());
+  const rulePaths = values.rulesdir?.map((rulePath) => rulePath.toString());
+  const extensions = values.ext?.map((extension) => extension.toString()).flatMap((extension) => extension.split(','));
+  const formatterName = values.format;
+
   return {
     patterns,
     formatterName,
-    quiet: parsedArgv.quiet,
-    useEslintrc: parsedArgv.eslintrc,
-    overrideConfigFile: parsedArgv.config,
+    quiet: values.quiet,
+    useEslintrc: values.eslintrc,
+    overrideConfigFile: values.config,
     extensions,
     rulePaths,
-    ignorePath: parsedArgv.ignorePath,
-    cache: parsedArgv.cache,
-    cacheLocation: parsedArgv['cache-location'],
-    resolvePluginsRelativeTo: parsedArgv['resolve-plugins-relative-to'],
+    ignorePath: values['ignore-path'],
+    cache: values.cache,
+    cacheLocation: values['cache-location'],
+    resolvePluginsRelativeTo: values['resolve-plugins-relative-to'],
   };
 }


### PR DESCRIPTION
close: https://github.com/mizdra/eslint-interactive/issues/374

## Breaking Changes
- The boolean option no longer supports the argument (e.g. `--no-eslintrc=false` and `--cache=false` are not supported)