### PR TITLE
Disable cache by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Options:
       --ignore-path                  Specify path of ignore file                                                                    [string]
       --format                       Specify the format to be used for the `Display problem messages` action [string] [default: "codeframe"]
       --quiet                        Report errors only                                                           [boolean] [default: false]
-      --cache                        Only check changed files                                                      [boolean] [default: true]
+      --cache                        Only check changed files                                                     [boolean] [default: false]
       --cache-location               Path to the cache file or directory
                                                             [string] [default: "node_modules/.cache/eslint-interactive/10.6.0/.eslintcache"]
       --flag                         Enable a feature flag (requires ESLint v9.6.0+)                                                 [array]

--- a/README.md
+++ b/README.md
@@ -83,8 +83,7 @@ Options:
       --format                       Specify the format to be used for the `Display problem messages` action [string] [default: "codeframe"]
       --quiet                        Report errors only                                                           [boolean] [default: false]
       --cache                        Only check changed files                                                     [boolean] [default: false]
-      --cache-location               Path to the cache file or directory
-                                                            [string] [default: "node_modules/.cache/eslint-interactive/10.6.0/.eslintcache"]
+      --cache-location               Path to the cache file or directory                                                            [string]
       --flag                         Enable a feature flag (requires ESLint v9.6.0+)                                                 [array]
 
 

--- a/src/cli/parse-argv.ts
+++ b/src/cli/parse-argv.ts
@@ -1,6 +1,4 @@
-import { join, relative } from 'node:path';
 import { parseArgs } from 'node:util';
-import { getCacheDir } from '../util/cache.js';
 import type { DeepPartial } from '../util/type-check.js';
 import { VERSION } from './package.js';
 
@@ -25,7 +23,6 @@ export const cliOptionsDefaults = {
   quiet: false,
   useEslintrc: true,
   cache: false,
-  cacheLocation: relative(process.cwd(), join(getCacheDir(), '.eslintcache')),
 } satisfies DeepPartial<ParsedCLIOptions>;
 
 /** Parse CLI options */
@@ -40,7 +37,7 @@ export function parseArgv(argv: string[]): ParsedCLIOptions {
     'format': { type: 'string', default: cliOptionsDefaults.formatterName },
     'quiet': { type: 'boolean', default: cliOptionsDefaults.quiet },
     'cache': { type: 'boolean', default: cliOptionsDefaults.cache },
-    'cache-location': { type: 'string', default: cliOptionsDefaults.cacheLocation },
+    'cache-location': { type: 'string' },
     'version': { type: 'boolean' },
     'help': { type: 'boolean' },
     'flag': { type: 'string', multiple: true },

--- a/src/cli/parse-argv.ts
+++ b/src/cli/parse-argv.ts
@@ -24,7 +24,7 @@ export const cliOptionsDefaults = {
   formatterName: 'stylish',
   quiet: false,
   useEslintrc: true,
-  cache: true,
+  cache: false,
   cacheLocation: relative(process.cwd(), join(getCacheDir(), '.eslintcache')),
 } satisfies DeepPartial<ParsedCLIOptions>;
 
@@ -75,7 +75,7 @@ Options:
       --ignore-path                  Specify path of ignore file                                                                      [string]
       --format                       Specify the format to be used for the \`Display problem messages\` action [string] [default: "codeframe"]
       --quiet                        Report errors only                                                             [boolean] [default: false]
-      --cache                        Only check changed files                                                        [boolean] [default: true]
+      --cache                        Only check changed files                                                       [boolean] [default: false]
       --cache-location               Path to the cache file or directory                                                              [string]
       --flag                         Enable a feature flag (requires ESLint v9.6.0+)                                                   [array]
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -85,7 +85,7 @@ export const configDefaults = {
     rulePaths: undefined,
     ignorePath: undefined,
     cache: cliOptionsDefaults.cache,
-    cacheLocation: cliOptionsDefaults.cacheLocation,
+    cacheLocation: undefined,
     overrideConfig: undefined,
     resolvePluginsRelativeTo: undefined,
   },


### PR DESCRIPTION
Since eslint also has caching disabled by default, we will change eslint-interactive to follow suit.

This change is also intended to remove `find-cache-dir` from eslint-interactive's dependencies in the future.

## Breaking Changes
- Disable cache by default
- Do not overwrite the default value of `--cache-location`