### PR TITLE
Fix failure to write details of lint results to file

### DIFF
--- a/e2e-test/flat-config/index.test.ts
+++ b/e2e-test/flat-config/index.test.ts
@@ -53,13 +53,20 @@ test('fix problems with flat config', async () => {
   child.stdin.write(LF); // Confirm the choice
   await streamWatcher.match(/Which action do you want to do\?/);
 
-  // Test pager
+  // Test for `Print in terminal with pager`
   child.stdin.write(LF); // Select `Display details of lint results`
   await streamWatcher.match(/In what way are the details displayed\?/);
   child.stdin.write('1'); // Focus on `Print in terminal with pager`
   child.stdin.write(LF); // Confirm the choice
   await streamWatcher.match(/prefer-const/);
   child.stdin.write('q'); // Exit pager
+
+  // Test for `Write to file`
+  child.stdin.write(LF); // Select `Display details of lint results`
+  await streamWatcher.match(/In what way are the details displayed\?/);
+  child.stdin.write('2'); // Focus on `Write to file`
+  child.stdin.write(LF); // Confirm the choice
+  await streamWatcher.match(/Wrote to/);
 
   // Test fixing
   child.stdin.write('1'); // Focus on `Run `eslint --fix``

--- a/src/action/apply-suggestions.ts
+++ b/src/action/apply-suggestions.ts
@@ -28,8 +28,7 @@ export async function doApplySuggestionsAction(
       await writeFile(filterScriptFilePath, exampleScript);
     }
   } else {
-    // ディレクトリがない可能性を考慮して作成しておく
-    await mkdir(dirname(filterScriptFilePath), { recursive: true });
+    await mkdir(dirname(filterScriptFilePath), { recursive: true }); // Create the directory because it might not exist
     await writeFile(filterScriptFilePath, exampleScript);
   }
   console.log('Opening editor...');

--- a/src/action/make-fixable-and-fix.ts
+++ b/src/action/make-fixable-and-fix.ts
@@ -28,8 +28,7 @@ export async function doMakeFixableAndFixAction(
       await writeFile(fixableMakerScriptFilePath, exampleScript);
     }
   } else {
-    // ディレクトリがない可能性を考慮して作成しておく
-    await mkdir(dirname(fixableMakerScriptFilePath), { recursive: true });
+    await mkdir(dirname(fixableMakerScriptFilePath), { recursive: true }); // Create the directory because it might not exist
     await writeFile(fixableMakerScriptFilePath, exampleScript);
   }
   console.log('Opening editor...');

--- a/src/action/print-result-details.ts
+++ b/src/action/print-result-details.ts
@@ -1,4 +1,5 @@
 import { writeFile } from 'node:fs/promises';
+import { mkdir } from 'node:fs/promises';
 import { join } from 'node:path';
 import { stripVTControlCharacters, styleText } from 'node:util';
 import type { Remote } from 'comlink';
@@ -21,7 +22,9 @@ export async function doPrintResultDetailsAction(
   } else if (displayMode === 'printInTerminalWithPager') {
     await pager(formattedResultDetails);
   } else if (displayMode === 'writeToFile') {
-    const filePath = join(getTempDir(), 'lint-result-details.txt');
+    const tempDir = getTempDir();
+    const filePath = join(tempDir, 'lint-result-details.txt');
+    await mkdir(tempDir, { recursive: true }); // Create the directory because it might not exist
     await writeFile(filePath, stripVTControlCharacters(formattedResultDetails), 'utf8');
     console.log(styleText('cyan', `Wrote to ${filePath}`));
   } else {


### PR DESCRIPTION
## Before
```console
$ pnpm run dev

...
✔ Which rules would you like to apply action? · no-unused-vars
✔ Which action do you want to do? · printResultDetails
✔ In what way are the details displayed? · writeToFile
Error: ENOENT: no such file or directory, open '/var/folders/0g/124lprqd1bzc_rw8q7ws4dww0000gn/T/eslint-interactive/11.1.0/lint-result-details.txt'
    at async open (node:internal/fs/promises:634:25)
    at async writeFile (node:internal/fs/promises:1208:14)
    at async doPrintResultDetailsAction (file:///Users/mizdra/src/github.com/mizdra/eslint-interactive/dist/action/print-result-details.js:19:9)
    at async selectAction (file:///Users/mizdra/src/github.com/mizdra/eslint-interactive/dist/scene/select-action.js:20:9)
    at async run (file:///Users/mizdra/src/github.com/mizdra/eslint-interactive/dist/cli/run.js:53:25) {
  errno: -2,
  code: 'ENOENT',
  syscall: 'open',
  path: '/var/folders/0g/124lprqd1bzc_rw8q7ws4dww0000gn/T/eslint-interactive/11.1.0/lint-result-details.txt'
}
```

## After
```console
$ pnpm run dev

...
✔ Which rules would you like to apply action? · no-unused-vars
✔ Which action do you want to do? · printResultDetails
✔ In what way are the details displayed? · writeToFile
Wrote to /var/folders/0g/124lprqd1bzc_rw8q7ws4dww0000gn/T/eslint-interactive/11.1.0/lint-result-details.txt
```