### PR TITLE
chore: disable watch mode in test script

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "lint:tsc": "tsc -p tsconfig.json --noEmit",
     "lint:eslint": "eslint .",
     "lint:prettier": "prettier --check .",
-    "test": "vitest",
+    "test": "vitest --run",
     "e2e": "run-s e2e:prepare e2e:run",
     "e2e:prepare": "pnpm run build --noCheck",
     "e2e:run": "vitest -c vite.config.e2e.ts"


### PR DESCRIPTION
## Summary
- Add `--run` flag to vitest in the `test` script so that `pnpm run test` always runs tests once and exits
- Watch mode is still available via `pnpm exec vitest` directly

## Test plan
- [x] `pnpm run test` runs tests and exits without entering watch mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)