### PR TITLE
docs: add commit message convention to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,3 +77,9 @@ Higher-level orchestration: call Core methods, show spinners, handle user prompt
 ### ESLint Internals (`src/eslint/`)
 
 This code is forked from the internal ESLint API. Since the API required to implement eslint-interactive is not publicly exposed by ESLint, we are doing this.
+
+## Other
+
+- Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
+  - `<type>` is one of: feat, fix, docs, refactor, test, chore, deps
+  - Example: `feat: implement some feature`


### PR DESCRIPTION
## Summary
- Add commit message convention section to AGENTS.md
- Document that commit messages follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) with allowed type prefixes: feat, fix, docs, refactor, test, chore, deps

## Test plan
- [x] Verify the added section is correctly formatted in AGENTS.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)