### PR TITLE
Flatten ESLint options into Config interface

### DIFF
--- a/docs/programmable-api.md
+++ b/docs/programmable-api.md
@@ -17,9 +17,6 @@ import { Core, takeRuleStatistics } from 'eslint-interactive';
 const core = new Core({
   patterns: ['example'],
   cwd: resolve('./github.com/mizdra/eslint-interactive'),
-  eslintOptions: {
-    type: 'flat',
-  },
 });
 const results = await core.lint();
 
@@ -95,12 +92,10 @@ import { Core, takeRuleStatistics } from 'eslint-interactive';
 const core = new Core({
   patterns: ['src'],
   cwd: resolve('./github.com/mizdra/eslint-interactive'),
-  eslintOptions: {
-    overrideConfigFile: true,
-    overrideConfig: {
-      rules: {
-        'sort-keys': 'error',
-      },
+  overrideConfigFile: true,
+  overrideConfig: {
+    rules: {
+      'sort-keys': 'error',
     },
   },
 });

--- a/e2e-test/import-as-esm-from-esm/index.test.ts
+++ b/e2e-test/import-as-esm-from-esm/index.test.ts
@@ -31,7 +31,6 @@ afterEach(async () => {
 test('Programmable API', async () => {
   const core = new Core({
     patterns: ['src'],
-    eslintOptions: {},
     cwd: iff.rootDir,
   });
   const results = await core.lint();

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,19 +3,11 @@ import type { ParsedCLIOptions } from './cli/parse-argv.js';
 import { cliOptionsDefaults } from './cli/parse-argv.js';
 import type { DeepPartial } from './util/type-check.js';
 
-export type ESLintOptions = { type: 'flat' } & Pick<
-  ESLint.Options,
-  'overrideConfigFile' | 'cache' | 'cacheLocation' | 'overrideConfig' | 'cwd' | 'flags'
->;
-
 /** The config of eslint-interactive */
-export type Config = {
+export type Config = ESLint.Options & {
   patterns: string[];
   formatterName?: string | undefined;
   quiet?: boolean | undefined;
-  cwd?: string | undefined;
-  eslintOptions: ESLintOptions;
-  flags?: string[] | undefined;
 };
 
 export function translateCLIOptions(options: ParsedCLIOptions): Config {
@@ -23,13 +15,10 @@ export function translateCLIOptions(options: ParsedCLIOptions): Config {
     patterns: options.patterns,
     formatterName: options.formatterName,
     quiet: options.quiet,
-    eslintOptions: {
-      type: 'flat',
-      overrideConfigFile: options.overrideConfigFile,
-      cache: options.cache,
-      cacheLocation: options.cacheLocation,
-      flags: options.flags,
-    },
+    overrideConfigFile: options.overrideConfigFile,
+    cache: options.cache,
+    cacheLocation: options.cacheLocation,
+    flags: options.flags,
   };
 }
 
@@ -38,38 +27,32 @@ export const configDefaults = {
   formatterName: cliOptionsDefaults.formatterName,
   quiet: cliOptionsDefaults.quiet,
   cwd: process.cwd(),
-  eslintOptions: {
-    overrideConfigFile: undefined,
-    cache: cliOptionsDefaults.cache,
-    cacheLocation: undefined,
-    overrideConfig: undefined,
-    flags: undefined,
-  },
+  overrideConfigFile: undefined,
+  cache: cliOptionsDefaults.cache,
+  cacheLocation: undefined,
+  overrideConfig: undefined,
+  flags: undefined,
 } satisfies DeepPartial<Config>;
 
-export type NormalizedConfig = {
+export type NormalizedConfig = ESLint.Options & {
   patterns: string[];
   formatterName: string;
   quiet: boolean;
   cwd: string;
-  eslintOptions: ESLintOptions;
 };
 
 export function normalizeConfig(config: Config): NormalizedConfig {
   const cwd = config.cwd ?? configDefaults.cwd;
   return {
+    ...config,
     patterns: config.patterns,
     formatterName: config.formatterName ?? configDefaults.formatterName,
     quiet: config.quiet ?? configDefaults.quiet,
     cwd,
-    eslintOptions: {
-      type: 'flat',
-      overrideConfigFile: config.eslintOptions.overrideConfigFile ?? configDefaults.eslintOptions.overrideConfigFile,
-      cache: config.eslintOptions.cache ?? configDefaults.eslintOptions.cache,
-      cacheLocation: config.eslintOptions.cacheLocation ?? configDefaults.eslintOptions.cacheLocation,
-      overrideConfig: config.eslintOptions.overrideConfig ?? configDefaults.eslintOptions.overrideConfig,
-      cwd,
-      flags: config.eslintOptions.flags ?? configDefaults.eslintOptions.flags,
-    },
+    overrideConfigFile: config.overrideConfigFile ?? configDefaults.overrideConfigFile,
+    cache: config.cache ?? configDefaults.cache,
+    cacheLocation: config.cacheLocation ?? configDefaults.cacheLocation,
+    overrideConfig: config.overrideConfig ?? configDefaults.overrideConfig,
+    flags: config.flags ?? configDefaults.flags,
   };
 }

--- a/src/core.test.ts
+++ b/src/core.test.ts
@@ -142,7 +142,6 @@ const core = new Core({
   patterns: ['src'],
   formatterName: 'stylish',
   cwd: iff.rootDir,
-  eslintOptions: { type: 'flat' },
 });
 
 beforeEach(async () => {
@@ -159,17 +158,14 @@ describe('Core', () => {
       const core = new Core({
         patterns: ['src'],
         cwd: iff.rootDir,
-        eslintOptions: {
-          type: 'flat',
-          overrideConfigFile: true,
-          overrideConfig: {
-            files: ['**/*.js'],
-            languageOptions: {
-              ecmaVersion: 2021,
-              sourceType: 'module',
-            },
-            rules: { 'prefer-const': 'error' },
+        overrideConfigFile: true,
+        overrideConfig: {
+          files: ['**/*.js'],
+          languageOptions: {
+            ecmaVersion: 2021,
+            sourceType: 'module',
           },
+          rules: { 'prefer-const': 'error' },
         },
       });
       const results = await core.lint();
@@ -318,9 +314,6 @@ describe('Core', () => {
     const core = new Core({
       patterns: ['src'],
       cwd: iff.rootDir,
-      eslintOptions: {
-        type: 'flat',
-      },
     });
     const results = await core.lint();
     expect(normalizeResults(results, iff.rootDir)).toMatchSnapshot();
@@ -356,10 +349,7 @@ describe('Core', () => {
     const core = new Core({
       patterns: ['src'],
       cwd: iff.rootDir,
-      eslintOptions: {
-        type: 'flat',
-        flags: ['unstable_config_lookup_from_file'],
-      },
+      flags: ['unstable_config_lookup_from_file'],
     });
 
     const results = await core.lint();

--- a/src/core.ts
+++ b/src/core.ts
@@ -42,7 +42,7 @@ export class Core {
 
   constructor(config: Config) {
     this.config = normalizeConfig(config);
-    const { type, ...eslintOptions } = this.config.eslintOptions;
+    const { formatterName, patterns, quiet, ...eslintOptions } = this.config;
     const overrideConfigs =
       Array.isArray(eslintOptions.overrideConfig) ? eslintOptions.overrideConfig
       : eslintOptions.overrideConfig ? [eslintOptions.overrideConfig]

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 export { run, type Options } from './cli/run.js';
 export { Core } from './core.js';
-export { type Config, type ESLintOptions, configDefaults } from './config.js';
+export { type Config, configDefaults } from './config.js';
 export { takeRuleStatistics, type RuleStatistic } from './formatter/index.js';
 export { type FixableMaker, type SuggestionFilter, type FixContext } from './fix/index.js';


### PR DESCRIPTION
ref: #404 

## Breaking Change

- Remove the `eslintOptions` property from `Config`; ESLint options are now passed as top-level properties
- Remove the `ESLintOptions` type export and `eslintOptions.type` option

## New Feature
- `Config` now extends `ESLint.Options`, accepting all ESLint options instead of a limited subset (`overrideConfigFile`, `cache`, `cacheLocation`, `overrideConfig`, `cwd`, `flags`)
