### PR TITLE
chore: add `--run` flag to e2e vitest command

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test": "vitest --run",
     "e2e": "run-s e2e:prepare e2e:run",
     "e2e:prepare": "pnpm run build --noCheck",
-    "e2e:run": "vitest -c vite.config.e2e.ts"
+    "e2e:run": "vitest -c vite.config.e2e.ts --run"
   },
   "prettier": "@mizdra/prettier-config-mizdra",
   "packageManager": "pnpm@10.10.0",


### PR DESCRIPTION
## Summary
- Add `--run` flag to the e2e vitest command to run in non-watch mode
- This improves compatibility with Coding Agents, which cannot detect test completion when vitest runs in watch mode, causing them to hang

## Test plan
- [x] Verify `pnpm run e2e` runs in non-watch mode and exits after completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)