### PR TITLE
Add flat config requirement and legacy config note

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ It also supports the following actions in addition to `eslint --fix`. All action
 - Node.js `^20.19.0 || >=22.12.0`
 - ESLint `>=8.45.0`
   - If you use ESLint `<8.45.0`, use `eslint-interactive@^10`.
+- Flat config (`eslint.config.js`)
+  - If you use legacy config (`.eslintrc.*`), use `eslint-interactive@^10`.
 
 ## Installation
 


### PR DESCRIPTION
ref: #404
follow-up: #412

## Summary
- Add flat config (`eslint.config.js`) as a requirement in the README
- Note that users with legacy config (`.eslintrc.*`) should use `eslint-interactive@^10`

## Test plan
- [x] Verify README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)