### PR TITLE
Replace `node` arg with `range` arg in `FixableMaker`

### DIFF
--- a/docs/programmable-api.md
+++ b/docs/programmable-api.md
@@ -115,11 +115,7 @@ const core = new Core({
 const results = await core.lint();
 
 await core.applySuggestions(results, ['no-unsafe-negation'], (suggestions, message, context) => {
-  if (message.ruleId === 'no-unsafe-negation') {
-    return suggestions.find((s) => s.desc.startsWith('Wrap negation'));
-  }
-  // Apply the first suggestion
-  return suggestions[0];
+  return suggestions.find((s) => s.desc.startsWith('Wrap negation'));
 });
 ```
 
@@ -144,22 +140,15 @@ const core = new Core({
 });
 const results = await core.lint();
 
-await core.makeFixableAndFix(results, ['no-unused-vars'], (message, node, context) => {
-  if (!node || !node.range) return null;
-
-  if (message.ruleId === 'no-unused-vars') {
-    // Add underscore prefix to unused variables
-    if (node.type !== 'Identifier') return null;
-    return context.fixer.insertTextBefore(node, '_');
-  }
-  return null;
+await core.makeFixableAndFix(results, ['no-unused-vars'], (message, range, context) => {
+  return context.fixer.insertTextBeforeRange(range, '_');
 });
 ```
 
 The `FixableMaker` function receives:
 
 - `message` — The lint message (`Linter.LintMessage`) to create a fix for
-- `node` — The AST node (`estree.Node | null`) associated with the message
+- `range` — The range (`AST.Range`) associated with the message
 - `context` — The fix context (`FixContext`) containing `filename`, `sourceCode`, `messages`, `ruleIds`, and `fixer`
 
 Return a `Rule.Fix` object to apply, or `null`/`undefined` to skip the message. Use `context.fixer` (the `Rule.RuleFixer` API) to create fix objects.

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "@mizdra/eslint-config-mizdra": "^7.0.0",
     "@mizdra/inline-fixture-files": "^2.1.1",
     "@mizdra/prettier-config-mizdra": "^2.0.0",
-    "@types/estraverse": "^5.1.7",
     "@types/estree": "^1.0.8",
     "@types/node": "^22.15.3",
     "dedent": "^1.5.3",
@@ -51,7 +50,6 @@
   "dependencies": {
     "comlink": "^4.4.1",
     "enquirer": "^2.4.1",
-    "estraverse": "^5.3.0",
     "is-installed-globally": "^1.0.0",
     "nanospinner": "^1.2.2",
     "terminal-link": "^3.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,9 +14,6 @@ importers:
       enquirer:
         specifier: ^2.4.1
         version: 2.4.1
-      estraverse:
-        specifier: ^5.3.0
-        version: 5.3.0
       is-installed-globally:
         specifier: ^1.0.0
         version: 1.0.0
@@ -39,9 +36,6 @@ importers:
       '@mizdra/prettier-config-mizdra':
         specifier: ^2.0.0
         version: 2.0.0(prettier@3.5.3)
-      '@types/estraverse':
-        specifier: ^5.1.7
-        version: 5.1.7
       '@types/estree':
         specifier: ^1.0.8
         version: 1.0.8
@@ -503,9 +497,6 @@ packages:
 
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
-
-  '@types/estraverse@5.1.7':
-    resolution: {integrity: sha512-JRVtdKYZz7VkNp7hMC/WKoiZ8DS3byw20ZGoMZ1R8eBrBPIY7iBaDAS1zcrnXQCwK44G4vbXkimeU7R0VLG8UQ==}
 
   '@types/estree@1.0.7':
     resolution: {integrity: sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==}
@@ -2262,10 +2253,6 @@ snapshots:
     optional: true
 
   '@rtsao/scc@1.1.0': {}
-
-  '@types/estraverse@5.1.7':
-    dependencies:
-      '@types/estree': 1.0.8
 
   '@types/estree@1.0.7': {}
 

--- a/src/core.test.ts
+++ b/src/core.test.ts
@@ -271,9 +271,9 @@ describe('Core', () => {
     const results = await core.lint();
     const original = await readFile(iff.paths['src/no-unused-vars.js'], 'utf-8');
 
-    const undo = await core.makeFixableAndFix(results, ['no-unused-vars'], (_message, node) => {
-      if (!node || !node.range) return null;
-      return { range: [node.range[0], node.range[0]], text: '_' };
+    const undo = await core.makeFixableAndFix(results, ['no-unused-vars'], (_message, range) => {
+      if (!range) return null;
+      return { range: [range[0], range[0]], text: '_' };
     });
 
     expect(await readFile(iff.paths['src/no-unused-vars.js'], 'utf-8')).toMatchSnapshot();

--- a/src/fix/make-fixable-and-fix.ts
+++ b/src/fix/make-fixable-and-fix.ts
@@ -1,12 +1,9 @@
-import type { Linter, Rule, SourceCode } from 'eslint';
-import { traverse } from 'estraverse';
-import type { Node } from 'estree';
-import { unreachable } from '../util/type-check.js';
+import type { AST, Linter, Rule, SourceCode } from 'eslint';
 import type { FixContext } from './index.js';
 
 export type FixableMaker = (
   message: Linter.LintMessage,
-  node: Node | null,
+  range: AST.Range,
   context: FixContext,
 ) => Rule.Fix | null | undefined;
 
@@ -14,58 +11,29 @@ export type FixToMakeFixableAndFixArgs = {
   fixableMaker: FixableMaker;
 };
 
-/**
- * Check the node is the source of the message.
- */
-function isMessageSourceNode(sourceCode: SourceCode, node: Node, message: Linter.LintMessage): boolean {
-  // eslint-disable-next-line @typescript-eslint/no-deprecated -- TODO: Do not use `nodeType` in the future.
-  if (message.nodeType === undefined) return false;
-
-  // In some cases there may be no `endLine` or `endColumn`.
-  if (message.endLine === undefined || message.endColumn === undefined) return false;
-  // If `nodeType` is exists, `range` must be exists.
-  if (node.range === undefined) return unreachable();
-
+function getMessageRange(sourceCode: SourceCode, message: Linter.LintMessage): AST.Range {
   const index = sourceCode.getIndexFromLoc({
     line: message.line,
     // NOTE: `column` of `ESLint.LintMessage` is 1-based, but `column` of `ESTree.Position` is 0-based.
     column: message.column - 1,
   });
-  const endIndex = sourceCode.getIndexFromLoc({
-    line: message.endLine,
-    // NOTE: `column` of `ESLint.LintMessage` is 1-based, but `column` of `ESTree.Position` is 0-based.
-    column: message.endColumn - 1,
-  });
-  // eslint-disable-next-line @typescript-eslint/no-deprecated -- TODO: Do not use `nodeType` in the future.
-  const nodeType = message.nodeType;
-
-  return node.range[0] === index && node.range[1] === endIndex && node.type === nodeType;
-}
-
-function getMessageToSourceNode(sourceCode: SourceCode, messages: Linter.LintMessage[]): Map<Linter.LintMessage, Node> {
-  const result = new Map<Linter.LintMessage, Node>();
-
-  traverse(sourceCode.ast, {
-    // Required to traverse extension nodes such as `JSXElement`.
-    fallback: 'iteration',
-    enter(node: Node) {
-      for (const message of messages) {
-        if (isMessageSourceNode(sourceCode, node, message)) {
-          result.set(message, node);
-        }
-      }
-    },
-  });
-  return result;
+  if (message.endLine && message.endColumn) {
+    const endIndex = sourceCode.getIndexFromLoc({
+      line: message.endLine,
+      // NOTE: `column` of `ESLint.LintMessage` is 1-based, but `column` of `ESTree.Position` is 0-based.
+      column: message.endColumn - 1,
+    });
+    return [index, endIndex];
+  } else {
+    return [index, index];
+  }
 }
 
 function generateFixes(context: FixContext, args: FixToMakeFixableAndFixArgs): Rule.Fix[] {
-  const messageToNode = getMessageToSourceNode(context.sourceCode, context.messages);
-
   const fixes: Rule.Fix[] = [];
   for (const message of context.messages) {
-    const node = messageToNode.get(message) ?? null;
-    const fix = args.fixableMaker(message, node, context);
+    const range = getMessageRange(context.sourceCode, message);
+    const fix = args.fixableMaker(message, range, context);
     if (fix) fixes.push(fix);
   }
   return fixes;

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -18,6 +18,20 @@ export const plugin: ESLint.Plugin = {
         return {};
       },
     },
+    /** This is a rule for testing purposes. It reports without end location (endLine/endColumn). */
+    'report-without-end-location': {
+      create(context: Rule.RuleContext) {
+        return {
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          Program(node) {
+            context.report({
+              loc: node.loc!.start,
+              message: 'Report without end location.',
+            });
+          },
+        };
+      },
+    },
     /** This is a rule for testing purposes. */
     'prefer-addition-shorthand': {
       meta: {


### PR DESCRIPTION
ref: #404 

## Summary

- Replace `node` (`estree.Node | null`) parameter with `range` (`AST.Range`) in `FixableMaker` callback to prepare for ESLint v10 compatibility
- ESLint v10 removes `nodeType` from `Linter.LintMessage`, which breaks the AST node lookup used by `makeFixableAndFix`
- Remove `estraverse` dependency which is no longer needed

## Test plan

- [x] Unit tests updated to use `range` instead of `node`
- [x] Verify `pnpm run test` passes
- [x] Verify `pnpm run lint:tsc` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)