### PR TITLE
Replace terminal-link with custom OSC 8 implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,8 +52,7 @@
     "vitest": "^2.1.1"
   },
   "dependencies": {
-    "enquirer": "^2.4.1",
-    "terminal-link": "^3.0.0"
+    "enquirer": "^2.4.1"
   },
   "peerDependencies": {
     "eslint": ">=9.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,6 @@ importers:
       enquirer:
         specifier: ^2.4.1
         version: 2.4.1
-      terminal-link:
-        specifier: ^3.0.0
-        version: 3.0.0
     devDependencies:
       '@eslint/eslintrc':
         specifier: ^3.3.3
@@ -651,10 +648,6 @@ packages:
   ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
     engines: {node: '>=6'}
-
-  ansi-escapes@5.0.0:
-    resolution: {integrity: sha512-5GFMVX8HqE/TB+FuBJGuO5XG0WrsA6ptUqoODaT/n9mmUaZFkqnBueB4leqGBCmrUHnCnC4PCZTCd0E7QQ83bA==}
-    engines: {node: '>=12'}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -1622,10 +1615,6 @@ packages:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
 
-  supports-hyperlinks@2.3.0:
-    resolution: {integrity: sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==}
-    engines: {node: '>=8'}
-
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
@@ -1633,10 +1622,6 @@ packages:
   tapable@2.2.1:
     resolution: {integrity: sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==}
     engines: {node: '>=6'}
-
-  terminal-link@3.0.0:
-    resolution: {integrity: sha512-flFL3m4wuixmf6IfhFJd1YPiLiMuxEc8uHRM1buzIeZPm22Au2pDqBJQgdo7n1WfPU1ONFGv7YDwpFBmHGF6lg==}
-    engines: {node: '>=12'}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -1674,10 +1659,6 @@ packages:
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
-
-  type-fest@1.4.0:
-    resolution: {integrity: sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==}
-    engines: {node: '>=10'}
 
   typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
@@ -2385,10 +2366,6 @@ snapshots:
       uri-js: 4.4.1
 
   ansi-colors@4.1.3: {}
-
-  ansi-escapes@5.0.0:
-    dependencies:
-      type-fest: 1.4.0
 
   ansi-regex@5.0.1: {}
 
@@ -3642,19 +3619,9 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
-  supports-hyperlinks@2.3.0:
-    dependencies:
-      has-flag: 4.0.0
-      supports-color: 7.2.0
-
   supports-preserve-symlinks-flag@1.0.0: {}
 
   tapable@2.2.1: {}
-
-  terminal-link@3.0.0:
-    dependencies:
-      ansi-escapes: 5.0.0
-      supports-hyperlinks: 2.3.0
 
   tinybench@2.9.0: {}
 
@@ -3683,8 +3650,6 @@ snapshots:
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
-
-  type-fest@1.4.0: {}
 
   typed-array-buffer@1.0.3:
     dependencies:

--- a/src/formatter/format-by-rules.ts
+++ b/src/formatter/format-by-rules.ts
@@ -1,8 +1,8 @@
 // eslint-disable-next-line n/no-unsupported-features/node-builtins
 import { styleText } from 'node:util';
 import type { ESLint } from 'eslint';
-import terminalLink from 'terminal-link';
 import type { SortField, SortOrder } from '../type.js';
+import { terminalLink } from '../util/terminal-link.js';
 import { ERROR_COLOR } from './colors.js';
 import { formatTable } from './format-table.js';
 import { sortRuleStatistics } from './sort-rule-statistics.js';
@@ -42,7 +42,7 @@ export function formatByRules(
     const { ruleId, errorCount, warningCount, isFixableCount, hasSuggestionsCount } = ruleStatistic;
     const ruleMetaData = data?.rulesMeta[ruleId];
     rows.push([
-      ruleMetaData?.docs?.url ? terminalLink(ruleId, ruleMetaData?.docs.url, { fallback: false }) : ruleId,
+      ruleMetaData?.docs?.url ? terminalLink(ruleId, ruleMetaData?.docs.url) : ruleId,
       numCell(errorCount),
       numCell(warningCount),
       numCell(isFixableCount),

--- a/src/formatter/format-table.test.ts
+++ b/src/formatter/format-table.test.ts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line n/no-unsupported-features/node-builtins
 import { stripVTControlCharacters, styleText } from 'node:util';
-import terminalLink from 'terminal-link';
 import { describe, expect, test } from 'vitest';
+import { terminalLink } from '../util/terminal-link.js';
 import { formatTable } from './format-table.js';
 
 const headerRow = ['Rule', 'Error', 'Warning', 'is fixable', 'has suggestions'];

--- a/src/util/terminal-link.test.ts
+++ b/src/util/terminal-link.test.ts
@@ -1,0 +1,26 @@
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import { terminalLink } from './terminal-link.js';
+
+const ORIGINAL_ENV = { ...process.env };
+
+beforeEach(() => {
+  for (const key of Object.keys(process.env)) delete process.env[key];
+  Object.assign(process.env, ORIGINAL_ENV);
+});
+
+afterEach(() => {
+  for (const key of Object.keys(process.env)) delete process.env[key];
+  Object.assign(process.env, ORIGINAL_ENV);
+});
+
+describe('terminalLink', () => {
+  test('emits OSC 8 escape sequence when hyperlinks are supported', () => {
+    process.env['FORCE_HYPERLINK'] = '1';
+    expect(terminalLink('text', 'https://example.com')).toBe('\x1B]8;;https://example.com\x07text\x1B]8;;\x07');
+  });
+
+  test('returns plain text when hyperlinks are not supported', () => {
+    process.env['FORCE_HYPERLINK'] = '0';
+    expect(terminalLink('text', 'https://example.com')).toBe('text');
+  });
+});

--- a/src/util/terminal-link.ts
+++ b/src/util/terminal-link.ts
@@ -1,0 +1,16 @@
+const OSC = '\x1B]';
+const BEL = '\x07';
+
+function buildOsc8Link(text: string, url: string): string {
+  return `${OSC}8;;${url}${BEL}${text}${OSC}8;;${BEL}`;
+}
+
+function supportsHyperlinks(): boolean {
+  if (process.env['FORCE_HYPERLINK'] === '1') return true;
+  if (process.env['FORCE_HYPERLINK'] === '0') return false;
+  return process.stdout.isTTY;
+}
+
+export function terminalLink(text: string, url: string): string {
+  return supportsHyperlinks() ? buildOsc8Link(text, url) : text;
+}


### PR DESCRIPTION
## Motivation
Supply-chain attacks targeting the npm registry have become increasingly common. Each direct or transitive dependency expands the attack surface, so dropping a dependency that can be replaced with a small amount of in-tree code is a worthwhile trade-off.

`terminal-link` is used in exactly one place (rendering ESLint rule documentation URLs as clickable hyperlinks in the rule table). The behavior we actually rely on — wrapping text in OSC 8 escape sequences when the output is a TTY — is small enough to implement directly, so we no longer need to depend on this package or its transitive deps.

## Summary
- Replace the `terminal-link` package with a small in-tree utility that emits OSC 8 hyperlink escape sequences.
- Remove `terminal-link` from `dependencies` together with its transitive deps (`ansi-escapes`, `supports-hyperlinks`, `type-fest`) to reduce supply-chain risk.
- The new utility honors `FORCE_HYPERLINK=1`/`0` for explicit override and falls back to `process.stdout.isTTY` otherwise.

## Test plan
- [x] `pnpm run lint` passes
- [x] `pnpm run test` passes (snapshots unchanged)
- [x] `pnpm run build` passes
- [x] Verified the built output emits OSC 8 sequences on a TTY

🤖 Generated with [Claude Code](https://claude.com/claude-code)