### PR TITLE
Replace enquirer with @clack/prompts

### DIFF
--- a/e2e-test/flat-config/index.test.ts
+++ b/e2e-test/flat-config/index.test.ts
@@ -10,7 +10,8 @@ import { fileURLToPath } from 'url';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 const ETX = String.fromCharCode(0x03); // ^C
-const LF = String.fromCharCode(0x0a); // \n
+const CR = String.fromCharCode(0x0d); // \r (Enter in raw mode)
+const DOWN = '\x1B[B'; // arrow down
 
 const iff = await createIFF({
   'src/index.js': 'let a = 1;',
@@ -50,27 +51,27 @@ test('fix problems with flat config', async () => {
 
   await streamWatcher.match(/Which rules would you like to apply action\?/);
   child.stdin.write(' '); // Select `prefer-const` rule
-  child.stdin.write(LF); // Confirm the choice
+  child.stdin.write(CR); // Confirm the choice
   await streamWatcher.match(/Which action do you want to do\?/);
 
   // Test for `Print in terminal with pager`
-  child.stdin.write(LF); // Select `Display details of lint results`
+  child.stdin.write(CR); // Select `Display details of lint results`
   await streamWatcher.match(/In what way are the details displayed\?/);
-  child.stdin.write('1'); // Focus on `Print in terminal with pager`
-  child.stdin.write(LF); // Confirm the choice
+  child.stdin.write(DOWN); // Focus on `Print in terminal with pager`
+  child.stdin.write(CR); // Confirm the choice
   await streamWatcher.match(/prefer-const/);
   child.stdin.write('q'); // Exit pager
 
   // Test for `Write to file`
-  child.stdin.write(LF); // Select `Display details of lint results`
+  child.stdin.write(CR); // Select `Display details of lint results`
   await streamWatcher.match(/In what way are the details displayed\?/);
-  child.stdin.write('2'); // Focus on `Write to file`
-  child.stdin.write(LF); // Confirm the choice
+  child.stdin.write(DOWN.repeat(2)); // Focus on `Write to file`
+  child.stdin.write(CR); // Confirm the choice
   await streamWatcher.match(/Wrote to/);
 
   // Test fixing
-  child.stdin.write('1'); // Focus on `Run `eslint --fix``
-  child.stdin.write(LF); // Confirm the choice
+  child.stdin.write(DOWN); // Focus on `Run `eslint --fix``
+  child.stdin.write(CR); // Confirm the choice
   await streamWatcher.match(/What's the next step\?/);
   expect(await readFile(iff.paths['src/index.js'], 'utf-8')).toMatchSnapshot();
 
@@ -92,12 +93,12 @@ test('go back to the rule selection screen ', async () => {
 
   await streamWatcher.match(/Which rules would you like to apply action\?/);
   child.stdin.write(' '); // Select `prefer-const` rule
-  child.stdin.write(LF); // Confirm the choice
+  child.stdin.write(CR); // Confirm the choice
   await streamWatcher.match(/Which action do you want to do\?/);
 
   // Select "Go back"
-  child.stdin.write('6'); // Focus on `Go back`
-  child.stdin.write(LF); // Confirm the choice
+  child.stdin.write(DOWN.repeat(6)); // Focus on `Go back`
+  child.stdin.write(CR); // Confirm the choice
 
   // Should go back to rule selection with fresh lint results
   await streamWatcher.match(/Which rules would you like to apply action\?/);

--- a/package.json
+++ b/package.json
@@ -44,15 +44,15 @@
     "@types/node": "^22.15.3",
     "dedent": "^1.5.3",
     "eslint": "^10.0.1",
-    "eslint-v9": "npm:eslint@^9.39.4",
     "eslint-v10": "npm:eslint@^10.0.1",
+    "eslint-v9": "npm:eslint@^9.39.4",
     "prettier": "3.5.3",
     "stream-match": "^4.1.0",
     "typescript": "^5.8.3",
     "vitest": "^2.1.1"
   },
   "dependencies": {
-    "enquirer": "^2.4.1"
+    "@clack/prompts": "^1.3.0"
   },
   "peerDependencies": {
     "eslint": ">=9.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,9 @@ importers:
 
   .:
     dependencies:
-      enquirer:
-        specifier: ^2.4.1
-        version: 2.4.1
+      '@clack/prompts':
+        specifier: ^1.3.0
+        version: 1.3.0
     devDependencies:
       '@eslint/eslintrc':
         specifier: ^3.3.3
@@ -129,6 +129,14 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@clack/core@1.3.0':
+    resolution: {integrity: sha512-xJPHpAmEQUBrXSLx0gF+q5K/IyihXpsHZcha+jB+tyahsKRK3Dxo4D0coZDewHo12NhiuzC3dTtMPbm53GEAAA==, tarball: https://registry.npmjs.org/@clack/core/-/core-1.3.0.tgz}
+    engines: {node: '>= 20.12.0'}
+
+  '@clack/prompts@1.3.0':
+    resolution: {integrity: sha512-GgcWwRCs/xPtaqlMy8qRhPnZf9vlWcWZNHAitnVQ3yk7JmSralSiq5q07yaffYE8SogtDm7zFeKccx1QNVARpw==, tarball: https://registry.npmjs.org/@clack/prompts/-/prompts-1.3.0.tgz}
+    engines: {node: '>= 20.12.0'}
 
   '@esbuild/aix-ppc64@0.21.5':
     resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==, tarball: https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz}
@@ -645,14 +653,6 @@ packages:
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==, tarball: https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz}
 
-  ansi-colors@4.1.3:
-    resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
-    engines: {node: '>=6'}
-
-  ansi-regex@5.0.1:
-    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
-    engines: {node: '>=8'}
-
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==, tarball: https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz}
     engines: {node: '>=8'}
@@ -847,10 +847,6 @@ packages:
     resolution: {integrity: sha512-ZSW3ma5GkcQBIpwZTSRAI8N71Uuwgs93IezB7mf7R60tC8ZbJideoDNKjHn2O9KIlx6rkGTTEk1xUCK2E1Y2Yg==}
     engines: {node: '>=10.13.0'}
 
-  enquirer@2.4.1:
-    resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
-    engines: {node: '>=8.6'}
-
   es-abstract@1.23.9:
     resolution: {integrity: sha512-py07lI0wjxAC/DcfK1S6G7iANonniZwTISvdPzk9hzeH0IZIshbuuFxLIU96OyF89Yb9hiqWn8M/bY83KY5vzA==}
     engines: {node: '>= 0.4'}
@@ -1031,6 +1027,15 @@ packages:
 
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fast-string-truncated-width@3.0.3:
+    resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==, tarball: https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz}
+
+  fast-string-width@3.0.2:
+    resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==, tarball: https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz}
+
+  fast-wrap-ansi@0.2.0:
+    resolution: {integrity: sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==, tarball: https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.0.tgz}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -1567,6 +1572,9 @@ packages:
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
+  sisteransi@1.0.5:
+    resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==, tarball: https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -1602,10 +1610,6 @@ packages:
   string.prototype.trimstart@1.0.8:
     resolution: {integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==}
     engines: {node: '>= 0.4'}
-
-  strip-ansi@6.0.1:
-    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
-    engines: {node: '>=8'}
 
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
@@ -1912,6 +1916,18 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@clack/core@1.3.0':
+    dependencies:
+      fast-wrap-ansi: 0.2.0
+      sisteransi: 1.0.5
+
+  '@clack/prompts@1.3.0':
+    dependencies:
+      '@clack/core': 1.3.0
+      fast-string-width: 3.0.2
+      fast-wrap-ansi: 0.2.0
+      sisteransi: 1.0.5
 
   '@esbuild/aix-ppc64@0.21.5':
     optional: true
@@ -2365,10 +2381,6 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
-  ansi-colors@4.1.3: {}
-
-  ansi-regex@5.0.1: {}
-
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
@@ -2579,11 +2591,6 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.2.1
-
-  enquirer@2.4.1:
-    dependencies:
-      ansi-colors: 4.1.3
-      strip-ansi: 6.0.1
 
   es-abstract@1.23.9:
     dependencies:
@@ -2975,6 +2982,16 @@ snapshots:
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
+
+  fast-string-truncated-width@3.0.3: {}
+
+  fast-string-width@3.0.2:
+    dependencies:
+      fast-string-truncated-width: 3.0.3
+
+  fast-wrap-ansi@0.2.0:
+    dependencies:
+      fast-string-width: 3.0.2
 
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
@@ -3550,6 +3567,8 @@ snapshots:
 
   siginfo@2.0.0: {}
 
+  sisteransi@1.0.5: {}
+
   source-map-js@1.2.1: {}
 
   stackback@0.0.2: {}
@@ -3608,10 +3627,6 @@ snapshots:
       call-bind: 1.0.8
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
-
-  strip-ansi@6.0.1:
-    dependencies:
-      ansi-regex: 5.0.1
 
   strip-json-comments@3.1.1: {}
 

--- a/src/action/convert-error-to-warning-per-file.ts
+++ b/src/action/convert-error-to-warning-per-file.ts
@@ -9,7 +9,7 @@ export async function doConvertErrorToWarningPerFileAction(
   selectedRuleIds: string[],
 ): Promise<Undo> {
   const description = await promptToInputDescription();
-  const undo = await withProgress('Fixing...', async () =>
+  const undo = await withProgress('Fixing', async () =>
     core.convertErrorToWarningPerFile(results, selectedRuleIds, description),
   );
   return undo;

--- a/src/action/disable-per-file.ts
+++ b/src/action/disable-per-file.ts
@@ -14,7 +14,7 @@ export async function doDisablePerFileAction(
   if (description) {
     descriptionPosition = await promptToInputDescriptionPosition();
   }
-  const undo = await withProgress('Fixing...', async () =>
+  const undo = await withProgress('Fixing', async () =>
     core.disablePerFile(results, selectedRuleIds, description, descriptionPosition),
   );
   return undo;

--- a/src/action/disable-per-line.ts
+++ b/src/action/disable-per-line.ts
@@ -14,7 +14,7 @@ export async function doDisablePerLineAction(
   if (description) {
     descriptionPosition = await promptToInputDescriptionPosition();
   }
-  const undo = await withProgress('Fixing...', async () =>
+  const undo = await withProgress('Fixing', async () =>
     core.disablePerLine(results, selectedRuleIds, description, descriptionPosition),
   );
   return undo;

--- a/src/action/fix.ts
+++ b/src/action/fix.ts
@@ -3,6 +3,6 @@ import { withProgress } from '../cli/log.js';
 import type { Core, Undo } from '../core.js';
 
 export async function doFixAction(core: Core, results: ESLint.LintResult[], selectedRuleIds: string[]): Promise<Undo> {
-  const undo = await withProgress('Fixing...', async () => core.applyAutoFixes(results, selectedRuleIds));
+  const undo = await withProgress('Fixing', async () => core.applyAutoFixes(results, selectedRuleIds));
   return undo;
 }

--- a/src/action/print-result-details.ts
+++ b/src/action/print-result-details.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 // eslint-disable-next-line n/no-unsupported-features/node-builtins
 import { stripVTControlCharacters, styleText } from 'node:util';
+import { log } from '@clack/prompts';
 import type { ESLint } from 'eslint';
 import { VERSION } from '../cli/package.js';
 import { pager } from '../cli/pager.js';
@@ -15,7 +16,7 @@ export async function doPrintResultDetailsAction(core: Core, results: ESLint.Lin
   const displayMode = await promptToInputDisplayMode();
   const formattedResultDetails = await core.formatResultDetails(results, selectedRuleIds);
   if (displayMode === 'printInTerminal') {
-    console.log(formattedResultDetails);
+    log.message(formattedResultDetails);
   } else if (displayMode === 'printInTerminalWithPager') {
     await pager(formattedResultDetails);
   } else if (displayMode === 'writeToFile') {
@@ -23,7 +24,7 @@ export async function doPrintResultDetailsAction(core: Core, results: ESLint.Lin
     const filePath = join(tempDir, 'lint-result-details.txt');
     await mkdir(tempDir, { recursive: true }); // Create the directory because it might not exist
     await writeFile(filePath, stripVTControlCharacters(formattedResultDetails), 'utf8');
-    console.log(styleText('cyan', `Wrote to ${filePath}`));
+    log.message(styleText('cyan', `Wrote to ${filePath}`));
   } else {
     // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
     unreachable(`Unknown display mode: ${displayMode}`);

--- a/src/cli/log.ts
+++ b/src/cli/log.ts
@@ -1,5 +1,6 @@
 // eslint-disable-next-line n/no-unsupported-features/node-builtins
 import { styleText } from 'node:util';
+import { taskLog } from '@clack/prompts';
 
 /**
  * Log an error message to stderr
@@ -9,11 +10,15 @@ export function error(message: string) {
   process.stderr.write(styleText('red', 'Error') + ': ' + message + '\n');
 }
 
-export async function withProgress<T>(label: string, cb: () => Promise<T>): Promise<T> {
-  console.log(label);
+export async function withProgress<T>(taskName: 'Linting' | 'Fixing' | 'Undoing', cb: () => Promise<T>): Promise<T> {
+  const log = taskLog({
+    title: `${taskName}...`,
+  });
   startProgress();
   try {
-    return await cb();
+    const result = await cb();
+    log.success(`${taskName} completed.`);
+    return result;
   } finally {
     endProgress();
   }

--- a/src/cli/prompt.ts
+++ b/src/cli/prompt.ts
@@ -1,15 +1,16 @@
 /* istanbul ignore file */
 
-import enquirer from 'enquirer';
+import { isCancel, multiselect, select, text } from '@clack/prompts';
 import type { ESLint } from 'eslint';
 import { takeRuleStatistics } from '../formatter/index.js';
 
-const { prompt } = enquirer;
-
-// When combined with worker, for some reason the enquirer grabs the SIGINT and the process continues to survive.
-// Therefore, the process is explicitly terminated.
-// eslint-disable-next-line n/no-process-exit
-const onCancel = () => process.exit();
+function exitIfCancel<T>(value: T | symbol): T {
+  if (isCancel(value)) {
+    // eslint-disable-next-line n/no-process-exit
+    process.exit();
+  }
+  return value;
+}
 
 /**
  * The type that indicates what to do with the problems of selected rules.
@@ -45,21 +46,13 @@ export type DescriptionPosition = 'sameLine' | 'previousLine';
  * @returns The rule ids
  */
 export async function promptToInputRuleIds(ruleIdsInResults: string[]): Promise<string[]> {
-  const { ruleIds } = await prompt<{ ruleIds: string[] }>([
-    {
-      name: 'ruleIds',
-      type: 'multiselect',
+  return exitIfCancel(
+    await multiselect<string>({
       message: 'Which rules would you like to apply action?',
-      // @ts-expect-error
-      hint: 'Select all you want with <space> key.',
-      choices: ruleIdsInResults,
-      validate(value) {
-        return value.length === 0 ? `Select at least one rule with <space> key.` : true;
-      },
-      onCancel,
-    },
-  ]);
-  return ruleIds;
+      options: ruleIdsInResults.map((ruleId) => ({ value: ruleId })),
+      required: true,
+    }),
+  );
 }
 
 /**
@@ -81,29 +74,21 @@ export async function promptToInputAction(
     { isFixableCount: 0 },
   );
 
-  const choices = [
-    { name: 'printResultDetails', message: '🔎 Display details of lint results' },
-    { name: 'applyAutoFixes', message: '🔧 Run `eslint --fix`', disabled: foldedStatistics.isFixableCount === 0 },
-    { name: 'disablePerLine', message: '🔧 Disable per line' },
-    { name: 'disablePerFile', message: '🔧 Disable per file' },
-    { name: 'convertErrorToWarningPerFile', message: '🔧 Convert error to warning per file' },
-    { name: 'relintAndReselectRules', message: '↩️ Go back (with re-lint)' },
-    { name: 'reselectRules', message: '↩️ Go back' },
-  ];
-
-  const { action } = await prompt<{
-    action: Action;
-  }>([
-    {
-      name: 'action',
-      type: 'select',
+  return exitIfCancel(
+    await select<Action>({
       message: 'Which action do you want to do?',
-      choices,
-      initial: choices.findIndex((choice) => choice.name === initialAction) ?? 0,
-      onCancel,
-    },
-  ]);
-  return action;
+      options: [
+        { value: 'printResultDetails', label: '🔎 Display details of lint results' },
+        { value: 'applyAutoFixes', label: '🔧 Run `eslint --fix`', disabled: foldedStatistics.isFixableCount === 0 },
+        { value: 'disablePerLine', label: '🔧 Disable per line' },
+        { value: 'disablePerFile', label: '🔧 Disable per file' },
+        { value: 'convertErrorToWarningPerFile', label: '🔧 Convert error to warning per file' },
+        { value: 'relintAndReselectRules', label: '↩️ Go back (with re-lint)' },
+        { value: 'reselectRules', label: '↩️ Go back' },
+      ],
+      initialValue: initialAction,
+    }),
+  );
 }
 
 /**
@@ -111,22 +96,16 @@ export async function promptToInputAction(
  * @returns How to display
  */
 export async function promptToInputDisplayMode(): Promise<DisplayMode> {
-  const { displayMode } = await prompt<{
-    displayMode: DisplayMode;
-  }>([
-    {
-      name: 'displayMode',
-      type: 'select',
+  return exitIfCancel(
+    await select<DisplayMode>({
       message: 'In what way are the details displayed?',
-      choices: [
-        { name: 'printInTerminal', message: '🖨  Print in terminal' },
-        { name: 'printInTerminalWithPager', message: '↕️  Print in terminal with pager' },
-        { name: 'writeToFile', message: '📝 Write to file' },
+      options: [
+        { value: 'printInTerminal', label: '🖨  Print in terminal' },
+        { value: 'printInTerminalWithPager', label: '↕️  Print in terminal with pager' },
+        { value: 'writeToFile', label: '📝 Write to file' },
       ],
-      onCancel,
-    },
-  ]);
-  return displayMode;
+    }),
+  );
 }
 
 /**
@@ -134,17 +113,12 @@ export async function promptToInputDisplayMode(): Promise<DisplayMode> {
  * @returns The description
  */
 export async function promptToInputDescription(): Promise<string | undefined> {
-  const { description } = await prompt<{
-    description: string;
-  }>([
-    {
-      name: 'description',
-      type: 'input',
+  const description = exitIfCancel(
+    await text({
       message: 'Leave a code comment with your reason for fixing (Optional)',
-      onCancel,
-    },
-  ]);
-  return description === '' ? undefined : description;
+    }),
+  );
+  return description.trim() === '' ? undefined : description.trim();
 }
 
 /**
@@ -152,21 +126,15 @@ export async function promptToInputDescription(): Promise<string | undefined> {
  * @returns The description position
  */
 export async function promptToInputDescriptionPosition(): Promise<DescriptionPosition> {
-  const { descriptionPosition } = await prompt<{
-    descriptionPosition: DescriptionPosition;
-  }>([
-    {
-      name: 'descriptionPosition',
-      type: 'select',
+  return exitIfCancel(
+    await select<DescriptionPosition>({
       message: 'Where would you like to position the code comment?',
-      choices: [
-        { name: 'sameLine', message: "Same Line - Place on the same line as the eslint's disable comment." },
-        { name: 'previousLine', message: "Previous Line - Place on the line before the eslint's disable comment." },
+      options: [
+        { value: 'sameLine', label: "Same Line - Place on the same line as the eslint's disable comment." },
+        { value: 'previousLine', label: "Previous Line - Place on the line before the eslint's disable comment." },
       ],
-      onCancel,
-    },
-  ]);
-  return descriptionPosition;
+    }),
+  );
 }
 
 /**
@@ -174,18 +142,14 @@ export async function promptToInputDescriptionPosition(): Promise<DescriptionPos
  * @returns What to do next.
  */
 export async function promptToInputWhatToDoNext(): Promise<NextStep> {
-  const { nextStep } = await prompt<{ nextStep: NextStep }>([
-    {
-      name: 'nextStep',
-      type: 'select',
+  return exitIfCancel(
+    await select<NextStep>({
       message: "What's the next step?",
-      choices: [
-        { name: 'fixOtherRules', message: '🔧 Fix other rules' },
-        { name: 'undoTheFix', message: '↩️  Undo the fix' },
-        { name: 'exit', message: '💚 Exit' },
+      options: [
+        { value: 'fixOtherRules', label: '🔧 Fix other rules' },
+        { value: 'undoTheFix', label: '↩️  Undo the fix' },
+        { value: 'exit', label: '💚 Exit' },
       ],
-      onCancel,
-    },
-  ]);
-  return nextStep;
+    }),
+  );
 }

--- a/src/scene/check-results.ts
+++ b/src/scene/check-results.ts
@@ -31,14 +31,11 @@ export async function checkResults({
   const nextStep = await promptToInputWhatToDoNext();
   if (nextStep === 'exit') return { name: 'exit' };
   if (nextStep === 'undoTheFix') {
-    await withProgress('Undoing...', async () => undo());
+    await withProgress('Undoing', async () => undo());
     return {
       name: 'selectAction',
       args: { results, ruleIdsInResults, selectedRuleIds, initialAction: selectedAction },
     };
   }
-  console.log();
-  console.log('─'.repeat(process.stdout.columns));
-  console.log();
   return { name: 'lint' };
 }

--- a/src/scene/lint.ts
+++ b/src/scene/lint.ts
@@ -1,3 +1,4 @@
+import { log } from '@clack/prompts';
 import { error, withProgress } from '../cli/log.js';
 import type { Core } from '../core.js';
 import type { NextScene } from './index.js';
@@ -6,8 +7,7 @@ import type { NextScene } from './index.js';
  * Run the scene to lint.
  */
 export async function lint(core: Core): Promise<NextScene> {
-  const results = await withProgress('Linting...', async () => core.lint());
-  console.log();
+  const results = await withProgress('Linting', async () => core.lint());
 
   // Check for ESLint core problems (ruleId === null) first.
   // These represent config errors, syntax errors, etc. that eslint-interactive cannot fix.
@@ -19,7 +19,7 @@ export async function lint(core: Core): Promise<NextScene> {
         'Check the details of the problem and fix it. ' +
         'This is usually caused by the invalid eslint config or the invalid syntax of the linted code.',
     );
-    console.log(await core.formatResultDetails(results, [null]));
+    log.message(await core.formatResultDetails(results, [null]), {});
     // eslint-disable-next-line n/no-process-exit
     process.exit(1);
   }
@@ -27,11 +27,10 @@ export async function lint(core: Core): Promise<NextScene> {
   const ruleIdsInResults = core.getSortedRuleIdsInResults(results);
 
   if (ruleIdsInResults.length === 0) {
-    console.log('💚 No error found.');
+    log.message('💚 No error found.');
     return { name: 'exit' };
   }
-  console.log(core.formatResultSummary(results));
+  log.message(core.formatResultSummary(results));
 
-  console.log();
   return { name: 'selectRuleIds', args: { results, ruleIdsInResults } };
 }

--- a/src/typings/enquirer.d.ts
+++ b/src/typings/enquirer.d.ts
@@ -1,7 +1,0 @@
-export {};
-
-declare module 'enquirer' {
-  interface ArrayPromptOptions {
-    hint?: string;
-  }
-}


### PR DESCRIPTION
## Motivation

`enquirer` has been effectively unmaintained for over two years (no recent commits), and keeping it leaves us exposed to unfixed security issues and potential breakage on newer Node.js versions. Migrating to the actively maintained `@clack/prompts` secures long-term maintainability. As part of the migration, we also adopt clack's `taskLog` and `log.message` so the prompts and progress logs share a consistent visual style.

## Main Changes

- Rewrite the six prompt helpers in `src/cli/prompt.ts` to use `select` / `multiselect` / `text`, consolidating cancellation into a single `isCancel()` + `process.exit()` guard.
- Switch `withProgress` in `src/cli/log.ts` to a `taskLog`-based implementation; the label argument is now a typed `taskName`.
- Replace `console.log` calls with `@clack/prompts`'s `log.message`.
- Drop the manual separator drawing in `src/scene/check-results.ts` (clack's styling separates sections naturally).
- Delete the no-longer-needed `src/typings/enquirer.d.ts` (the `hint` type augmentation is unnecessary with clack).

## Test plan

- [x] `pnpm run lint` passes
- [x] `pnpm run test` passes
- [x] `pnpm run e2e` passes (updated the multiselect submit key from `LF` to `CR`, and replaced digit-key jumps with arrow-key navigation)
- [x] Manually verify each prompt (rule selection, action selection, display-mode selection, description input, description-position selection, next-step selection) with `pnpm run dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)