### PR TITLE
Support `--filter` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ Options:
       --flag <name>             Enable a feature flag (requires ESLint v9.6.0+)
       --sort <field>            Sort rules by: rule, error, warning, fixable, suggestions
       --sort-order <direction>  Sort direction: asc, desc (default: desc for counts, asc for rule)
+      --filter <criterion>      Show only rules matching the criterion: fixable, has-suggestions
+                                (repeatable; multiple values are OR-ed)
 
 Examples:
   eslint-interactive                          Lint all files in the project

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Examples:
   eslint-interactive 'src/**/*.{ts,tsx,vue}'  Lint with glob pattern
   eslint-interactive --sort error             Sort rules by error count (descending)
   eslint-interactive --sort rule              Sort rules by rule name (ascending)
+  eslint-interactive --filter fixable         Show only rules that have fixable problems
 ```
 
 ## Programmable API

--- a/src/cli/parse-argv.test.ts
+++ b/src/cli/parse-argv.test.ts
@@ -1,9 +1,17 @@
-import { describe, expect, test, vi } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { parseArgv } from './parse-argv.js';
 
 const baseArgs = ['node', 'eslint-interactive'];
 
+const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+  throw new Error(`process.exit(${code})`);
+}) as never);
+
 describe('parseArgv', () => {
+  beforeEach(() => {
+    errorSpy.mockClear();
+  });
   test('pattern', () => {
     expect(parseArgv([...baseArgs, 'foo']).patterns).toStrictEqual(['foo']);
     expect(parseArgv([...baseArgs, 'foo', 'bar']).patterns).toStrictEqual(['foo', 'bar']);
@@ -59,10 +67,18 @@ describe('parseArgv', () => {
     expect(parseArgv([...baseArgs, '--sort', 'fixable']).sort).toStrictEqual('fixable');
     expect(parseArgv([...baseArgs, '--sort', 'suggestions']).sort).toStrictEqual('suggestions');
   });
+  test('--sort with invalid value exits with code 1', () => {
+    expect(() => parseArgv([...baseArgs, '--sort', 'invalid'])).toThrow('process.exit(1)');
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('Invalid --sort value: "invalid"'));
+  });
   test('--sort-order', () => {
     expect(parseArgv([...baseArgs]).sortOrder).toStrictEqual(undefined);
     expect(parseArgv([...baseArgs, '--sort-order', 'asc']).sortOrder).toStrictEqual('asc');
     expect(parseArgv([...baseArgs, '--sort-order', 'desc']).sortOrder).toStrictEqual('desc');
+  });
+  test('--sort-order with invalid value exits with code 1', () => {
+    expect(() => parseArgv([...baseArgs, '--sort-order', 'invalid'])).toThrow('process.exit(1)');
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('Invalid --sort-order value: "invalid"'));
   });
   test('--filter', () => {
     expect(parseArgv([...baseArgs]).filters).toStrictEqual(undefined);
@@ -74,16 +90,7 @@ describe('parseArgv', () => {
     ]);
   });
   test('--filter with invalid value exits with code 1', () => {
-    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
-      throw new Error(`process.exit(${code})`);
-    }) as never);
-    try {
-      expect(() => parseArgv([...baseArgs, '--filter', 'invalid'])).toThrow('process.exit(1)');
-      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('Invalid --filter value: "invalid"'));
-    } finally {
-      errorSpy.mockRestore();
-      exitSpy.mockRestore();
-    }
+    expect(() => parseArgv([...baseArgs, '--filter', 'invalid'])).toThrow('process.exit(1)');
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('Invalid --filter value: "invalid"'));
   });
 });

--- a/src/cli/parse-argv.test.ts
+++ b/src/cli/parse-argv.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
 import { parseArgv } from './parse-argv.js';
 
 const baseArgs = ['node', 'eslint-interactive'];
@@ -63,5 +63,27 @@ describe('parseArgv', () => {
     expect(parseArgv([...baseArgs]).sortOrder).toStrictEqual(undefined);
     expect(parseArgv([...baseArgs, '--sort-order', 'asc']).sortOrder).toStrictEqual('asc');
     expect(parseArgv([...baseArgs, '--sort-order', 'desc']).sortOrder).toStrictEqual('desc');
+  });
+  test('--filter', () => {
+    expect(parseArgv([...baseArgs]).filters).toStrictEqual(undefined);
+    expect(parseArgv([...baseArgs, '--filter', 'fixable']).filters).toStrictEqual(['fixable']);
+    expect(parseArgv([...baseArgs, '--filter', 'has-suggestions']).filters).toStrictEqual(['has-suggestions']);
+    expect(parseArgv([...baseArgs, '--filter', 'fixable', '--filter', 'has-suggestions']).filters).toStrictEqual([
+      'fixable',
+      'has-suggestions',
+    ]);
+  });
+  test('--filter with invalid value exits with code 1', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`process.exit(${code})`);
+    }) as never);
+    try {
+      expect(() => parseArgv([...baseArgs, '--filter', 'invalid'])).toThrow('process.exit(1)');
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('Invalid --filter value: "invalid"'));
+    } finally {
+      errorSpy.mockRestore();
+      exitSpy.mockRestore();
+    }
   });
 });

--- a/src/cli/parse-argv.ts
+++ b/src/cli/parse-argv.ts
@@ -1,9 +1,10 @@
 import { parseArgs } from 'node:util';
-import type { Config, SortField, SortOrder } from '../type.js';
+import type { Config, FilterCriterion, SortField, SortOrder } from '../type.js';
 import { VERSION } from './package.js';
 
 const VALID_SORT_FIELDS: readonly SortField[] = ['rule', 'error', 'warning', 'fixable', 'suggestions'];
 const VALID_SORT_ORDERS: readonly SortOrder[] = ['asc', 'desc'];
+const VALID_FILTER_CRITERIA: readonly FilterCriterion[] = ['fixable', 'has-suggestions'];
 
 /** Parse CLI options */
 export function parseArgv(argv: string[]): Config {
@@ -20,6 +21,7 @@ export function parseArgv(argv: string[]): Config {
     'flag': { type: 'string', multiple: true },
     'sort': { type: 'string' },
     'sort-order': { type: 'string' },
+    'filter': { type: 'string', multiple: true },
   } as const;
 
   const { values, positionals } = parseArgs({
@@ -42,6 +44,15 @@ export function parseArgv(argv: string[]): Config {
     );
     // eslint-disable-next-line n/no-process-exit
     process.exit(1);
+  }
+  if (values.filter !== undefined) {
+    for (const filter of values.filter) {
+      if (!VALID_FILTER_CRITERIA.includes(filter as FilterCriterion)) {
+        console.error(`Invalid --filter value: "${filter}". Must be one of: ${VALID_FILTER_CRITERIA.join(', ')}`);
+        // eslint-disable-next-line n/no-process-exit
+        process.exit(1);
+      }
+    }
   }
 
   if (values.version) {
@@ -68,6 +79,8 @@ Options:
       --flag <name>             Enable a feature flag (requires ESLint v9.6.0+)
       --sort <field>            Sort rules by: rule, error, warning, fixable, suggestions
       --sort-order <direction>  Sort direction: asc, desc (default: desc for counts, asc for rule)
+      --filter <criterion>      Show only rules matching the criterion: fixable, has-suggestions
+                                (repeatable; multiple values are OR-ed)
 
 Examples:
   eslint-interactive                          Lint all files in the project
@@ -75,6 +88,7 @@ Examples:
   eslint-interactive 'src/**/*.{ts,tsx,vue}'  Lint with glob pattern
   eslint-interactive --sort error             Sort rules by error count (descending)
   eslint-interactive --sort rule              Sort rules by rule name (ascending)
+  eslint-interactive --filter fixable         Show only rules that have fixable problems
 `.trim(),
     );
     // eslint-disable-next-line n/no-process-exit
@@ -96,5 +110,6 @@ Examples:
     flags: values.flag,
     sort: values.sort as SortField | undefined,
     sortOrder: values['sort-order'] as SortOrder | undefined,
+    filters: values.filter as FilterCriterion[] | undefined,
   };
 }

--- a/src/core.ts
+++ b/src/core.ts
@@ -12,9 +12,9 @@ import {
   createFixToMakeFixableAndFix,
   verifyAndFix,
 } from './fix/index.js';
-import { format, sortRuleStatistics, takeRuleStatistics } from './formatter/index.js';
+import { filterRuleStatistics, format, sortRuleStatistics, takeRuleStatistics } from './formatter/index.js';
 import { plugin } from './plugin.js';
-import type { Config, SortField, SortOrder } from './type.js';
+import type { Config, FilterCriterion, SortField, SortOrder } from './type.js';
 import { filterResultsByRuleId } from './util/eslint.js';
 
 /**
@@ -42,6 +42,7 @@ export class Core {
   readonly #formatterName: string | undefined;
   readonly #sort: SortField | undefined;
   readonly #sortOrder: SortOrder | undefined;
+  readonly #filters: FilterCriterion[] | undefined;
   readonly #eslint: ESLint;
 
   constructor(config: Config) {
@@ -51,10 +52,11 @@ export class Core {
     this.#formatterName = config.formatterName;
     this.#sort = config.sort;
     this.#sortOrder = config.sortOrder;
+    this.#filters = config.filters;
 
     // NOTE: Passing an option that does not exist to `new ESLint(...)` will throw an error.
     // Therefore, only options supported by ESLint are extracted into the `eslintOptions` variable.
-    const { formatterName, patterns, quiet, sort, sortOrder, ...eslintOptions } = config;
+    const { formatterName, patterns, quiet, sort, sortOrder, filters, ...eslintOptions } = config;
     const overrideConfigs =
       Array.isArray(eslintOptions.overrideConfig) ? eslintOptions.overrideConfig
       : eslintOptions.overrideConfig ? [eslintOptions.overrideConfig]
@@ -93,11 +95,12 @@ export class Core {
   }
 
   /**
-   * Returns ruleIds from lint results, sorted according to the configured sort options.
+   * Returns ruleIds from lint results, filtered and sorted according to the configured options.
    * @param results The lint results of the project
    */
   getSortedRuleIdsInResults(results: ESLint.LintResult[]): string[] {
     let ruleStatistics = takeRuleStatistics(results);
+    ruleStatistics = filterRuleStatistics(ruleStatistics, this.#filters);
     if (this.#sort) {
       ruleStatistics = sortRuleStatistics(ruleStatistics, this.#sort, this.#sortOrder);
     }

--- a/src/core.ts
+++ b/src/core.ts
@@ -91,7 +91,11 @@ export class Core {
    */
   formatResultSummary(results: ESLint.LintResult[]): string {
     const rulesMeta = this.#eslint.getRulesMetaForResults(results);
-    return format(results, { rulesMeta, cwd: this.#cwd }, { sort: this.#sort, sortOrder: this.#sortOrder });
+    return format(
+      results,
+      { rulesMeta, cwd: this.#cwd },
+      { sort: this.#sort, sortOrder: this.#sortOrder, filters: this.#filters },
+    );
   }
 
   /**

--- a/src/core.ts
+++ b/src/core.ts
@@ -102,7 +102,7 @@ export class Core {
    * Returns ruleIds from lint results, filtered and sorted according to the configured options.
    * @param results The lint results of the project
    */
-  getSortedRuleIdsInResults(results: ESLint.LintResult[]): string[] {
+  getFilteredAndSortedRuleIds(results: ESLint.LintResult[]): string[] {
     let ruleStatistics = takeRuleStatistics(results);
     ruleStatistics = filterRuleStatistics(ruleStatistics, this.#filters);
     if (this.#sort) {

--- a/src/formatter/filter-rule-statistics.test.ts
+++ b/src/formatter/filter-rule-statistics.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from 'vitest';
+import { filterRuleStatistics } from './filter-rule-statistics.js';
+import type { RuleStatistic } from './take-rule-statistics.js';
+
+function fakeRuleStatistic(partial: Partial<RuleStatistic> & { ruleId: string }): RuleStatistic {
+  return {
+    errorCount: 0,
+    warningCount: 0,
+    isFixableCount: 0,
+    isFixableErrorCount: 0,
+    isFixableWarningCount: 0,
+    hasSuggestionsCount: 0,
+    hasSuggestionsErrorCount: 0,
+    hasSuggestionsWarningCount: 0,
+    ...partial,
+  };
+}
+
+describe('filterRuleStatistics', () => {
+  const statistics: RuleStatistic[] = [
+    fakeRuleStatistic({ ruleId: 'fixable-only', isFixableCount: 3, hasSuggestionsCount: 0 }),
+    fakeRuleStatistic({ ruleId: 'suggestions-only', isFixableCount: 0, hasSuggestionsCount: 2 }),
+    fakeRuleStatistic({ ruleId: 'both', isFixableCount: 1, hasSuggestionsCount: 1 }),
+    fakeRuleStatistic({ ruleId: 'neither', isFixableCount: 0, hasSuggestionsCount: 0 }),
+  ];
+
+  test('returns the input unchanged when criteria is undefined', () => {
+    expect(filterRuleStatistics(statistics, undefined)).toBe(statistics);
+  });
+  test('returns the input unchanged when criteria is empty', () => {
+    expect(filterRuleStatistics(statistics, [])).toBe(statistics);
+  });
+  test('filters by "fixable"', () => {
+    const result = filterRuleStatistics(statistics, ['fixable']);
+    expect(result.map((s) => s.ruleId)).toEqual(['fixable-only', 'both']);
+  });
+  test('filters by "has-suggestions"', () => {
+    const result = filterRuleStatistics(statistics, ['has-suggestions']);
+    expect(result.map((s) => s.ruleId)).toEqual(['suggestions-only', 'both']);
+  });
+  test('combines multiple criteria with OR', () => {
+    const result = filterRuleStatistics(statistics, ['fixable', 'has-suggestions']);
+    expect(result.map((s) => s.ruleId)).toEqual(['fixable-only', 'suggestions-only', 'both']);
+  });
+  test('preserves input order', () => {
+    const reversed = [...statistics].reverse();
+    const result = filterRuleStatistics(reversed, ['fixable', 'has-suggestions']);
+    expect(result.map((s) => s.ruleId)).toEqual(['both', 'suggestions-only', 'fixable-only']);
+  });
+});

--- a/src/formatter/filter-rule-statistics.ts
+++ b/src/formatter/filter-rule-statistics.ts
@@ -1,0 +1,27 @@
+import type { FilterCriterion } from '../type.js';
+import { unreachable } from '../util/type-check.js';
+import type { RuleStatistic } from './take-rule-statistics.js';
+
+function matchesCriterion(statistic: RuleStatistic, criterion: FilterCriterion): boolean {
+  switch (criterion) {
+    case 'fixable':
+      return statistic.isFixableCount > 0;
+    case 'has-suggestions':
+      return statistic.hasSuggestionsCount > 0;
+    default:
+      return unreachable(`Invalid filter criterion: ${criterion as string}`);
+  }
+}
+
+/**
+ * Filter rule statistics by the given criteria.
+ * Multiple criteria are OR-ed together; a statistic is kept if it matches any of them.
+ * When `criteria` is undefined or empty, the input is returned unchanged.
+ */
+export function filterRuleStatistics(
+  statistics: RuleStatistic[],
+  criteria: readonly FilterCriterion[] | undefined,
+): RuleStatistic[] {
+  if (!criteria || criteria.length === 0) return statistics;
+  return statistics.filter((statistic) => criteria.some((criterion) => matchesCriterion(statistic, criterion)));
+}

--- a/src/formatter/format-by-rules.test.ts
+++ b/src/formatter/format-by-rules.test.ts
@@ -65,6 +65,21 @@ describe('formatByRules', () => {
     const ruleBIndex = lines.findIndex((line) => line.includes('rule-b'));
     expect(ruleBIndex).toBeLessThan(ruleAIndex);
   });
+  test('filters rules when filters is provided', () => {
+    const results: ESLint.LintResult[] = [
+      fakeLintResult({
+        messages: [
+          fakeLintMessage({ ruleId: 'rule-fixable', severity: 2, fix: fakeFix() }),
+          fakeLintMessage({ ruleId: 'rule-suggest', severity: 2, suggestions: fakeSuggestions() }),
+          fakeLintMessage({ ruleId: 'rule-plain', severity: 2 }),
+        ],
+      }),
+    ];
+    const stripped = stripVTControlCharacters(formatByRules(results, undefined, { filters: ['fixable'] }));
+    expect(stripped).toContain('rule-fixable');
+    expect(stripped).not.toContain('rule-suggest');
+    expect(stripped).not.toContain('rule-plain');
+  });
   test('prints link', () => {
     const results: ESLint.LintResult[] = [
       fakeLintResult({

--- a/src/formatter/format-by-rules.ts
+++ b/src/formatter/format-by-rules.ts
@@ -1,9 +1,10 @@
 // eslint-disable-next-line n/no-unsupported-features/node-builtins
 import { styleText } from 'node:util';
 import type { ESLint } from 'eslint';
-import type { SortField, SortOrder } from '../type.js';
+import type { FilterCriterion, SortField, SortOrder } from '../type.js';
 import { terminalLink } from '../util/terminal-link.js';
 import { ERROR_COLOR } from './colors.js';
+import { filterRuleStatistics } from './filter-rule-statistics.js';
 import { formatTable } from './format-table.js';
 import { sortRuleStatistics } from './sort-rule-statistics.js';
 import { takeRuleStatistics } from './take-rule-statistics.js';
@@ -18,9 +19,10 @@ type Row = [
   hasSuggestionsCount: string,
 ];
 
-export type FormatByRulesSortOptions = {
+export type FormatByRulesOptions = {
   sort?: SortField | undefined;
   sortOrder?: SortOrder | undefined;
+  filters?: FilterCriterion[] | undefined;
 };
 
 function numCell(num: number): string {
@@ -30,11 +32,12 @@ function numCell(num: number): string {
 export function formatByRules(
   results: ESLint.LintResult[],
   data?: ESLint.LintResultData,
-  sortOptions?: FormatByRulesSortOptions,
+  options?: FormatByRulesOptions,
 ): string {
   let ruleStatistics = takeRuleStatistics(results);
-  if (sortOptions?.sort) {
-    ruleStatistics = sortRuleStatistics(ruleStatistics, sortOptions.sort, sortOptions.sortOrder);
+  ruleStatistics = filterRuleStatistics(ruleStatistics, options?.filters);
+  if (options?.sort) {
+    ruleStatistics = sortRuleStatistics(ruleStatistics, options.sort, options.sortOrder);
   }
 
   const rows: Row[] = [];

--- a/src/formatter/index.ts
+++ b/src/formatter/index.ts
@@ -4,6 +4,7 @@ import { formatByRules, type FormatByRulesSortOptions } from './format-by-rules.
 
 export { takeRuleStatistics, type RuleStatistic } from './take-rule-statistics.js';
 export { sortRuleStatistics } from './sort-rule-statistics.js';
+export { filterRuleStatistics } from './filter-rule-statistics.js';
 
 export function format(
   results: ESLint.LintResult[],

--- a/src/formatter/index.ts
+++ b/src/formatter/index.ts
@@ -1,6 +1,6 @@
 import type { ESLint } from 'eslint';
 import { formatByFiles } from './format-by-files.js';
-import { formatByRules, type FormatByRulesSortOptions } from './format-by-rules.js';
+import { formatByRules, type FormatByRulesOptions } from './format-by-rules.js';
 
 export { takeRuleStatistics, type RuleStatistic } from './take-rule-statistics.js';
 export { sortRuleStatistics } from './sort-rule-statistics.js';
@@ -9,7 +9,7 @@ export { filterRuleStatistics } from './filter-rule-statistics.js';
 export function format(
   results: ESLint.LintResult[],
   data?: ESLint.LintResultData,
-  sortOptions?: FormatByRulesSortOptions,
+  options?: FormatByRulesOptions,
 ): string {
-  return `${formatByFiles(results)}\n${formatByRules(results, data, sortOptions)}`;
+  return `${formatByFiles(results)}\n${formatByRules(results, data, options)}`;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 export { run, type Options } from './cli/run.js';
 export { Core } from './core.js';
-export { type SortField, type SortOrder, type Config } from './type.js';
+export { type SortField, type SortOrder, type FilterCriterion, type Config } from './type.js';
 export { takeRuleStatistics, type RuleStatistic, sortRuleStatistics } from './formatter/index.js';
 export { type FixableMaker, type SuggestionFilter, type FixContext } from './fix/index.js';

--- a/src/scene/lint.ts
+++ b/src/scene/lint.ts
@@ -24,10 +24,15 @@ export async function lint(core: Core): Promise<NextScene> {
     process.exit(1);
   }
 
-  const ruleIdsInResults = core.getSortedRuleIdsInResults(results);
+  const ruleIdsInResults = core.getFilteredAndSortedRuleIds(results);
 
   if (ruleIdsInResults.length === 0) {
-    log.message('💚 No error found.');
+    const hasAnyMessage = results.some((result) => result.messages.length > 0);
+    if (hasAnyMessage) {
+      log.message('💚 No rules match the given --filter.');
+    } else {
+      log.message('💚 No rules with problems.');
+    }
     return { name: 'exit' };
   }
   log.message(core.formatResultSummary(results));

--- a/src/type.ts
+++ b/src/type.ts
@@ -2,6 +2,7 @@ import type { ESLint } from 'eslint';
 
 export type SortField = 'rule' | 'error' | 'warning' | 'fixable' | 'suggestions';
 export type SortOrder = 'asc' | 'desc';
+export type FilterCriterion = 'fixable' | 'has-suggestions';
 
 /** The config of eslint-interactive */
 export type Config = ESLint.Options & {
@@ -10,4 +11,5 @@ export type Config = ESLint.Options & {
   quiet?: boolean | undefined;
   sort?: SortField | undefined;
   sortOrder?: SortOrder | undefined;
+  filters?: FilterCriterion[] | undefined;
 };


### PR DESCRIPTION
## Summary

Closes #296

Adds a `--filter` option to narrow the rules shown on the rule selection prompt. This implements the same idea as eslint-nibble's `--fixable-only` requested in #296.

<img width="927" height="470" alt="image" src="https://github.com/user-attachments/assets/fd32f3a6-e436-4a1c-afee-f20021b61d06" />


## Specification

- New `--filter <criterion>` CLI flag (`multiple: true`, repeatable)
- Allowed values: `fixable`, `has-suggestions`
- Multiple values are combined with **OR** (e.g. `--filter fixable --filter has-suggestions` selects rules with fixable problems _or_ rules with suggestions)
- Negation (`--reject` etc.) is intentionally out of scope and won't be supported

```console
$ eslint-interactive --filter fixable
$ eslint-interactive --filter fixable --filter has-suggestions
```

## Implementation

Implemented as a "display-only" filter:

- ESLint's config is left untouched; lint still runs against all rules
- Rules that don't match the filter are removed from the rule selection candidates produced by `selectRuleIds`
- Reuses `isFixableCount` / `hasSuggestionsCount` already exposed by `takeRuleStatistics`

drewgbarnes pointed out in #296 that filtering rules could speed up the lint itself. An execution-level alternative was prototyped on a separate worktree, but I chose not to ship it for now:

- Significantly more complex (depends on \`builtinRules\` from \`eslint/use-at-your-own-risk\`, has to probe \`calculateConfigForFile\` per file extension, etc.)
- Suppresses inline re-enables like \`/* eslint-enable rule-name */\`
- Speed work is better tackled in a dedicated issue once there's concrete demand

## Test plan

- [x] \`pnpm run lint\` passes
- [x] \`pnpm run test\` passes (added unit tests for \`filter-rule-statistics\` and validation tests for \`parse-argv\`)
- [x] Manually verify that \`--filter fixable\` only shows rules with at least one fixable problem
- [x] Manually verify that \`--filter has-suggestions\` only shows rules with at least one suggestion
- [x] Manually verify OR behavior with \`--filter fixable --filter has-suggestions\`
- [x] Manually verify that an invalid value such as \`--filter foo\` exits with an error