### PR TITLE
fix: add bugs.url to package.json for npm metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,5 +78,8 @@
     "!src/**/__snapshots__",
     "dist",
     "static"
-  ]
+  ],
+  "bugs": {
+    "url": "https://github.com/mizdra/eslint-interactive/issues"
+  }
 }


### PR DESCRIPTION
Adds the standard npm bugs field to package.json for better npm metadata. Co-authored-by: openhands <openhands@all-hands.dev>